### PR TITLE
Add user / project config types

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -1,4 +1,7 @@
-﻿Tyr.Common.Config.Storage.Initialize(args[0]);
+﻿using Config = Tyr.Common.Config;
+
+using var projectConfigs = new Config.Storage(args[0], Config.StorageType.Project);
+using var userConfigs = new Config.Storage("user.toml", Config.StorageType.User);
 
 using var sslVisionPublisher = new Tyr.Vision.SslVisionDataPublisher();
 using var gcPublisher = new Tyr.Referee.GcDataPublisher();

--- a/Common/Config/ConfigEntry.cs
+++ b/Common/Config/ConfigEntry.cs
@@ -10,8 +10,10 @@ public class ConfigEntry(PropertyInfo info, Configurable owner)
 
     public string Name => info.Name;
     public Type Type => info.PropertyType;
-    public string? Comment => _meta.Description;
     public object DefaultValue { get; } = info.GetValue(null)!;
+
+    public string? Description => _meta.Description;
+    public StorageType StorageType => _meta.StorageType;
 
     static ConfigEntry()
     {
@@ -27,14 +29,14 @@ public class ConfigEntry(PropertyInfo info, Configurable owner)
             if (Equals(current, value)) return;
 
             info.SetValue(null, value);
-            owner.OnChanged();
+            owner.OnChanged(StorageType);
         }
     }
 
     public TomlValue ToToml()
     {
         var value = TomletMain.ValueFrom(Type, Value);
-        value.Comments.PrecedingComment = Comment;
+        value.Comments.PrecedingComment = Description;
 
         if (value is not TomlArray)
             value.Comments.InlineComment = $"default: {DefaultValue}";

--- a/Common/Config/ConfigEntry.cs
+++ b/Common/Config/ConfigEntry.cs
@@ -14,6 +14,7 @@ public class ConfigEntry(PropertyInfo info, Configurable owner)
 
     public string? Description => _meta.Description;
     public StorageType StorageType => _meta.StorageType;
+    public bool Editable => _meta.Editable;
 
     static ConfigEntry()
     {
@@ -29,7 +30,7 @@ public class ConfigEntry(PropertyInfo info, Configurable owner)
             if (Equals(current, value)) return;
 
             info.SetValue(null, value);
-            owner.OnChanged(StorageType);
+            owner.MarkChanged(StorageType);
         }
     }
 

--- a/Common/Config/ConfigEntryAttribute.cs
+++ b/Common/Config/ConfigEntryAttribute.cs
@@ -1,7 +1,13 @@
 ﻿namespace Tyr.Common.Config;
 
 [AttributeUsage(AttributeTargets.Property)]
-public class ConfigEntryAttribute(string? description = null) : Attribute
+public class ConfigEntryAttribute(string? description = null, StorageType storageType = StorageType.Project)
+    : Attribute
 {
+    public ConfigEntryAttribute(StorageType storageType) : this(null, storageType)
+    {
+    }
+
     public string? Description { get; } = description;
+    public StorageType StorageType { get; } = storageType;
 }

--- a/Common/Config/ConfigEntryAttribute.cs
+++ b/Common/Config/ConfigEntryAttribute.cs
@@ -1,13 +1,18 @@
 ﻿namespace Tyr.Common.Config;
 
 [AttributeUsage(AttributeTargets.Property)]
-public class ConfigEntryAttribute(string? description = null, StorageType storageType = StorageType.Project)
+public class ConfigEntryAttribute(
+    string? description = null,
+    StorageType storageType = StorageType.Project,
+    bool editable = true)
     : Attribute
 {
-    public ConfigEntryAttribute(StorageType storageType) : this(null, storageType)
+    public ConfigEntryAttribute(StorageType storageType, bool editable = true)
+        : this(null, storageType, editable)
     {
     }
 
     public string? Description { get; } = description;
     public StorageType StorageType { get; } = storageType;
+    public bool Editable { get; set; } = editable;
 }

--- a/Common/Config/Configurable.cs
+++ b/Common/Config/Configurable.cs
@@ -31,7 +31,7 @@ public class Configurable
             .ToArray();
     }
 
-    public void OnChanged(StorageType storageType)
+    public void MarkChanged(StorageType storageType)
     {
         Log.ZLogTrace($"Configurable of type {Type.FullName} was updated.");
         OnUpdated?.Invoke(storageType);

--- a/Common/Config/Registry.cs
+++ b/Common/Config/Registry.cs
@@ -102,6 +102,9 @@ public static class Registry
 
         foreach (var configurable in Configurables.Values)
         {
+            var configurableToml = configurable.ToToml(storageType);
+            if (configurableToml.Entries.Count <= 0) continue;
+
             var path = ConvertPath($"{configurable.Namespace}.{configurable.Type.Name}");
             document.Put(path, configurable.ToToml(storageType));
         }

--- a/Common/Config/StorageType.cs
+++ b/Common/Config/StorageType.cs
@@ -1,0 +1,8 @@
+﻿namespace Tyr.Common.Config;
+
+// Defines storage location for configuration values
+public enum StorageType
+{
+    Project, // Stored in main project configuration
+    User, // Stored in user-specific configuration
+}

--- a/Common/Data/CommonConfigs.cs
+++ b/Common/Data/CommonConfigs.cs
@@ -10,6 +10,6 @@ public static partial class CommonConfigs
 
     [ConfigEntry("Hope it lasts")] public static bool ImmortalsIsTheBestTeam { get; set; } = true;
 
+    // TODO: this doesn't belong here as we want to host multiple AIs, this should be defined per-AI
     [ConfigEntry] public static TeamColor OurColor { get; set; } = TeamColor.Unknown;
-    [ConfigEntry] public static bool EnableDebug { get; set; } = false;
 }

--- a/Common/Debug/Drawing/Command.cs
+++ b/Common/Debug/Drawing/Command.cs
@@ -6,4 +6,9 @@ public readonly record struct Command(
     Options Options,
     Meta Meta,
     Timestamp Timestamp
-);
+)
+{
+    public static Command Empty => new(null!, Color.Black, new Options(), Meta.Empty, Timestamp.Now);
+
+    public bool IsEmpty => Drawable is null;
+}

--- a/Common/Debug/Drawing/Drawables/Empty.cs
+++ b/Common/Debug/Drawing/Drawables/Empty.cs
@@ -1,3 +1,0 @@
-﻿namespace Tyr.Common.Debug.Drawing.Drawables;
-
-public readonly record struct Empty : IDrawable;

--- a/Common/Debug/Drawing/Drawer.cs
+++ b/Common/Debug/Drawing/Drawer.cs
@@ -61,15 +61,6 @@ public sealed class Drawer(string moduleName) : IDisposable
         Hub.Draws.Publish(command);
     }
 
-    public void DrawEmpty(
-        [CallerMemberName] string? memberName = null,
-        [CallerFilePath] string? filePath = null,
-        [CallerLineNumber] int lineNumber = 0)
-    {
-        var empty = new Empty();
-        Draw(empty, Color.Black, default, "", memberName, filePath, lineNumber);
-    }
-
     public void DrawPoint(Vector2 position, Color color, Options options = default,
         [CallerArgumentExpression(nameof(position))]
         string? positionExpression = null,

--- a/Common/Debug/Drawing/Options.cs
+++ b/Common/Debug/Drawing/Options.cs
@@ -1,8 +1,3 @@
 ﻿namespace Tyr.Common.Debug.Drawing;
 
-public readonly record struct Options(
-    bool Filled = false,
-    float Thickness = 10f,
-    float Duration = 0f)
-{
-}
+public readonly record struct Options(bool Filled = false, float Thickness = 10f);

--- a/Common/Debug/Logging/Entry.cs
+++ b/Common/Debug/Logging/Entry.cs
@@ -7,4 +7,9 @@ public record Entry(
     LogLevel Level,
     Meta Meta,
     Timestamp Timestamp
-);
+)
+{
+    public static Entry Empty => new(string.Empty, LogLevel.None, Meta.Empty, Timestamp.Now);
+
+    public bool IsEmpty => Level == LogLevel.None;
+}

--- a/Common/Debug/Plotting/Command.cs
+++ b/Common/Debug/Plotting/Command.cs
@@ -6,4 +6,9 @@ public readonly record struct Command(
     string? Title,
     Meta Meta,
     Timestamp Timestamp
-);
+)
+{
+    public static Command Empty => new(string.Empty, null!, null, Meta.Empty, Timestamp.Now);
+
+    public bool IsEmpty => string.IsNullOrEmpty(Id);
+}

--- a/Common/Network/UdpReceiver.cs
+++ b/Common/Network/UdpReceiver.cs
@@ -6,39 +6,39 @@ public class UdpReceiver<T> : IDisposable where T : class
 {
     private readonly Action<T> _onData;
 
-    private readonly UdpClient _client;
-    private readonly RunnerAsync _runner;
+    public UdpClient Client { get; }
+    public RunnerAsync Runner { get; }
 
     public UdpReceiver(Address address, Action<T> onData, string? callingModule = null)
     {
         _onData = onData;
-        _client = new UdpClient(address);
+        Client = new UdpClient(address);
 
-        _runner = new RunnerAsync(Tick, 0, callingModule);
-        _runner.Start();
+        Runner = new RunnerAsync(Tick, 0, callingModule);
+        Runner.Start();
     }
 
     private async Task Tick(CancellationToken token)
     {
-        var packet = await _client.Receive<T>(token);
+        var packet = await Client.Receive<T>(token);
         if (packet == null)
         {
             if (!token.IsCancellationRequested)
             {
-                Log.ZLogError($"Received null {typeof(T).Name} packet");
+                Log.ZLogError($"Received null {typeof(T).Name}");
             }
 
             return;
         }
 
-        Log.ZLogTrace($"Received {typeof(T).Name} packet from {_client.GetLastReceiveEndpoint()}");
+        Log.ZLogTrace($"Received {typeof(T).Name} from {Client.GetLastReceiveEndpoint()}");
 
         _onData(packet);
     }
 
     public void Dispose()
     {
-        _runner.Stop();
-        _client.Dispose();
+        Runner.Stop();
+        Client.Dispose();
     }
 }

--- a/Common/Runner/RunnerAsync.cs
+++ b/Common/Runner/RunnerAsync.cs
@@ -8,9 +8,9 @@ public class RunnerAsync(Func<CancellationToken, Task> tick, int tickRateHz = 0,
     private Task? _task;
     private CancellationTokenSource? _cts;
 
-    public override bool IsRunning => _task != null;
+    public bool IsRunning => _task != null;
 
-    public override void Start()
+    public void Start()
     {
         if (IsRunning) return;
 
@@ -27,7 +27,7 @@ public class RunnerAsync(Func<CancellationToken, Task> tick, int tickRateHz = 0,
             TaskScheduler.Default);
     }
 
-    public override void Stop()
+    public void Stop()
     {
         if (!IsRunning) return;
 

--- a/Common/Runner/RunnerAsync.cs
+++ b/Common/Runner/RunnerAsync.cs
@@ -60,6 +60,8 @@ public class RunnerAsync(Func<CancellationToken, Task> tick, int tickRateHz = 0,
             var tickStart = Timer.Time;
             CurrentTickStartTimestamp = Timestamp.Now;
 
+            NewDebugFrame();
+
             Timer.Update();
 
             await tick(token);

--- a/Common/Runner/RunnerBase.cs
+++ b/Common/Runner/RunnerBase.cs
@@ -6,8 +6,6 @@ namespace Tyr.Common.Runner;
 
 public abstract class RunnerBase(int tickRateHz)
 {
-    public abstract bool IsRunning { get; }
-
     public Time.Timer Timer { get; } = new();
 
     public int TickRateHz { get; } = tickRateHz;
@@ -20,9 +18,6 @@ public abstract class RunnerBase(int tickRateHz)
     {
         TimerResolution.Set(DeltaTime.FromMilliseconds(1));
     }
-
-    public abstract void Start();
-    public abstract void Stop();
 
     protected void SleepUntil(Timestamp nextTick)
     {
@@ -47,8 +42,10 @@ public abstract class RunnerBase(int tickRateHz)
         };
         Hub.Frames.Publish(frame);
 
-        Draw.DrawEmpty();
-        Plot.Plot(string.Empty, 0);
-        Log.ZLogCritical($"");
+        // Send empty debug entries so that the frames can be sealed
+        // even when the frames do not contain any actual entries
+        Hub.Logs.Publish(Debug.Logging.Entry.Empty);
+        Hub.Draws.Publish(Debug.Drawing.Command.Empty);
+        Hub.Plots.Publish(Debug.Plotting.Command.Empty);
     }
 }

--- a/Common/Runner/RunnerBase.cs
+++ b/Common/Runner/RunnerBase.cs
@@ -31,7 +31,7 @@ public abstract class RunnerBase(int tickRateHz)
         while (Timer.Time < nextTick) ;
     }
 
-    public void NewDebugFrame()
+    protected void NewDebugFrame()
     {
         if (ModuleContext.Current.Value == null) return;
 

--- a/Common/Runner/RunnerSync.cs
+++ b/Common/Runner/RunnerSync.cs
@@ -25,6 +25,17 @@ public class RunnerSync(Action tick, int tickRateHz = 0, string? callingModule =
         _thread.Start();
     }
 
+    public void StartOnCurrentThread()
+    {
+        if (IsRunning) return;
+
+        Timer.Start();
+
+        _running = true;
+
+        Loop();
+    }
+
     public void Stop()
     {
         if (!IsRunning) return;

--- a/Common/Runner/RunnerSync.cs
+++ b/Common/Runner/RunnerSync.cs
@@ -7,9 +7,9 @@ public class RunnerSync(Action tick, int tickRateHz = 0, string? callingModule =
     private Thread? _thread;
     private volatile bool _running;
 
-    public override bool IsRunning => _running;
+    public bool IsRunning => _running;
 
-    public override void Start()
+    public void Start()
     {
         if (IsRunning) return;
 
@@ -25,7 +25,7 @@ public class RunnerSync(Action tick, int tickRateHz = 0, string? callingModule =
         _thread.Start();
     }
 
-    public override void Stop()
+    public void Stop()
     {
         if (!IsRunning) return;
 

--- a/Common/Runner/RunnerSync.cs
+++ b/Common/Runner/RunnerSync.cs
@@ -44,6 +44,8 @@ public class RunnerSync(Action tick, int tickRateHz = 0, string? callingModule =
             var tickStart = Timer.Time;
             CurrentTickStartTimestamp = Timestamp.Now;
 
+            NewDebugFrame();
+
             Timer.Update();
             tick();
 

--- a/Data/config.toml
+++ b/Data/config.toml
@@ -38,7 +38,7 @@ GrownUpAge = 3 # default: 3
 
 [Vision.SslVisionDataPublisher]
 VisionAddress = { Ip = "224.5.23.2", Port = 10006 } # default: 224.5.23.2:10006
-VisionSimAddress = { Ip = "224.5.23.2", Port = 10025 } # default: 224.5.23.2:10025
+SimulatorAddress = { Ip = "224.5.23.2", Port = 10025 } # default: 224.5.23.2:10025
 
 [Vision.Camera]
 # Time in [s] after an invisible ball is removed
@@ -67,6 +67,8 @@ Level = "Trace" # default: Debug
 
 [Common.Config]
 [Common.Config.Storage]
+MaxLoadAttempts = 10 # default: 10
+LoadAttemptsDelayMs = 100.0 # default: 100
 DebounceDelayS = 0.20000000298023224 # default: 0.2
 
 
@@ -88,9 +90,7 @@ FontSize = 17 # default: 17
 
 
 [Gui.Views]
-[Gui.Views.LogView]
-LogLevel = "Debug" # default: Debug
-
+LogView = {  }
 [Gui.Views.PlotView]
 TimeAxisExtension = 5.0 # default: 5
 TimeAxisMinRange = 1.0 # default: 1

--- a/Data/config.toml
+++ b/Data/config.toml
@@ -1,11 +1,50 @@
+[Common]
+[Common.Data]
+[Common.Data.CommonConfigs]
+# The variety of standard patterns that we can have is 16
+MaxRobots = 16 # default: 16
+# Hope it lasts
+ImmortalsIsTheBestTeam = true # default: True
+OurColor = "Unknown" # default: Unknown
+EnableDebug = false # default: False
+
+
+[Common.Config]
+[Common.Config.Storage]
+MaxLoadAttempts = 10 # default: 10
+LoadAttemptsDelayMs = 100.0 # default: 100
+DebounceDelayS = 0.20000000298023224 # default: 0.2
+
+
+[Common.Debug]
+[Common.Debug.Logging]
+[Common.Debug.Logging.Logging]
+# The level logs are filtered at the source. Anything below this will be rejected on the log call.
+Level = "Trace" # default: Debug
+
+
+[Common.Debug.Assertion]
+[Common.Debug.Assertion.Assert]
+Enabled = true # default: True
+
+
+
+
 [Vision]
-[Vision.Runner]
-TickRateHz = 100 # default: 100
-
-[Vision.Vision]
-CameraTooOldTime = 1.0 # default: 1
-
 [Vision.Tracker]
+[Vision.Tracker.Ball]
+InitialCovariance = 1000.0 # default: 1000
+ModelError = 0.10000000149011612 # default: 0.1
+MeasurementError = 100.0 # default: 100
+# Maximum assumed ball speed in [mm/s] to filter outliers
+MaxLinearVelocity = 15000.0 # default: 15000
+# Factor to weight stdDeviation during tracker merging, reasonable range: 1.0 - 2.0. High values lead to more jitter
+MergePower = 1.5 # default: 1.5
+# Reciprocal health is used as uncertainty, increased on update, decreased on prediction
+MaxHealth = 20 # default: 20
+# How many updates are required until this tracker is grown up?
+GrownUpAge = 3 # default: 3
+
 [Vision.Tracker.Robot]
 InitialCovarianceXy = 100.0 # default: 100
 ModelErrorXy = 0.10000000149011612 # default: 0.1
@@ -22,23 +61,6 @@ MaxAngularVelocity = 1700.0 # default: 1700
 # Reciprocal health is used as uncertainty, increased on update, decreased on prediction
 MaxHealth = 20 # default: 20
 
-[Vision.Tracker.Ball]
-InitialCovariance = 1000.0 # default: 1000
-ModelError = 0.10000000149011612 # default: 0.1
-MeasurementError = 100.0 # default: 100
-# Maximum assumed ball speed in [mm/s] to filter outliers
-MaxLinearVelocity = 15000.0 # default: 15000
-# Factor to weight stdDeviation during tracker merging, reasonable range: 1.0 - 2.0. High values lead to more jitter
-MergePower = 1.5 # default: 1.5
-# Reciprocal health is used as uncertainty, increased on update, decreased on prediction
-MaxHealth = 20 # default: 20
-# How many updates are required until this tracker is grown up?
-GrownUpAge = 3 # default: 3
-
-
-[Vision.SslVisionDataPublisher]
-VisionAddress = { Ip = "224.5.23.2", Port = 10006 } # default: 224.5.23.2:10006
-SimulatorAddress = { Ip = "224.5.23.2", Port = 10025 } # default: 224.5.23.2:10025
 
 [Vision.Camera]
 # Time in [s] after an invisible ball is removed
@@ -50,40 +72,19 @@ MaxBallTrackers = 10 # default: 10
 # Max. distance to copy state from filtered bot to new trackers
 CopyTrackerMaxDistance = 200.0 # default: 200
 
+[Vision.SslVisionDataPublisher]
+VisionAddress = { Ip = "224.5.23.2", Port = 10006 } # default: 224.5.23.2:10006
+SimulatorAddress = { Ip = "224.5.23.2", Port = 10025 } # default: 224.5.23.2:10025
 
-[Common]
-[Common.Debug]
-[Common.Debug.Assertion]
-[Common.Debug.Assertion.Assert]
-Enabled = true # default: True
+[Vision.Vision]
+CameraTooOldTime = 1.0 # default: 1
 
-
-[Common.Debug.Logging]
-[Common.Debug.Logging.Logging]
-# The level logs are filtered at the source. Anything below this will be rejected on the log call.
-Level = "Trace" # default: Debug
-
-
-
-[Common.Config]
-[Common.Config.Storage]
-MaxLoadAttempts = 10 # default: 10
-LoadAttemptsDelayMs = 100.0 # default: 100
-DebounceDelayS = 0.20000000298023224 # default: 0.2
-
-
-[Common.Data]
-[Common.Data.CommonConfigs]
-# The variety of standard patterns that we can have is 16
-MaxRobots = 16 # default: 16
-# Hope it lasts
-ImmortalsIsTheBestTeam = true # default: True
-OurColor = "Unknown" # default: Unknown
-EnableDebug = false # default: False
-
+[Vision.Runner]
+TickRateHz = 100 # default: 100
 
 
 [Gui]
+Runner = {  }
 [Gui.Backend]
 [Gui.Backend.FontRegistry]
 FontSize = 17 # default: 17

--- a/Data/config.toml
+++ b/Data/config.toml
@@ -84,14 +84,12 @@ TickRateHz = 100 # default: 100
 
 
 [Gui]
-Runner = {  }
 [Gui.Backend]
 [Gui.Backend.FontRegistry]
 FontSize = 17 # default: 17
 
 
 [Gui.Views]
-LogView = {  }
 [Gui.Views.PlotView]
 TimeAxisExtension = 5.0 # default: 5
 TimeAxisMinRange = 1.0 # default: 1

--- a/Data/config.toml
+++ b/Data/config.toml
@@ -6,7 +6,6 @@ MaxRobots = 16 # default: 16
 # Hope it lasts
 ImmortalsIsTheBestTeam = true # default: True
 OurColor = "Unknown" # default: Unknown
-EnableDebug = false # default: False
 
 
 [Common.Config]

--- a/Gui/Backend/GlfwWindow.cs
+++ b/Gui/Backend/GlfwWindow.cs
@@ -11,7 +11,7 @@ internal class GlfwWindow : IDisposable
 
     static GlfwWindow() => GLFW.Init();
 
-    public GlfwWindow(int w, int h, string title)
+    public GlfwWindow(string title, int w, int h, int? x = null, int? y = null, bool? maximized = null)
     {
         GLFW.WindowHint(GLFW.GLFW_CONTEXT_VERSION_MAJOR, 3);
         GLFW.WindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, 2);
@@ -19,6 +19,13 @@ internal class GlfwWindow : IDisposable
 
         GLFW.WindowHint(GLFW.GLFW_FOCUSED, 1); // Make window focused on start
         GLFW.WindowHint(GLFW.GLFW_RESIZABLE, 1); // Make window resizable
+
+        if (x.HasValue) GLFW.WindowHint(GLFW.GLFW_POSITION_X, x.Value);
+        if (y.HasValue) GLFW.WindowHint(GLFW.GLFW_POSITION_Y, y.Value);
+        if (maximized.HasValue)
+        {
+            GLFW.WindowHint(GLFW.GLFW_MAXIMIZED, maximized.Value ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
+        }
 
         Handle = GLFW.CreateWindow(w, h, title, null, null);
         if (Handle.IsNull) throw new Exception("GLFW window failed");
@@ -59,6 +66,22 @@ internal class GlfwWindow : IDisposable
         MakeContextCurrent();
         GLFW.SetWindowPos(Handle, w, h);
     }
+
+    public bool GetMaximized()
+    {
+        MakeContextCurrent();
+        return GLFW.GetWindowAttrib(Handle, GLFW.GLFW_MAXIMIZED) == GLFW.GLFW_TRUE;
+    }
+
+    public void SetMaximized(bool maximized)
+    {
+        MakeContextCurrent();
+        if (maximized)
+            GLFW.MaximizeWindow(Handle);
+        else
+            GLFW.RestoreWindow(Handle);
+    }
+
 
     public void MakeContextCurrent() => GLFW.MakeContextCurrent(Handle);
 

--- a/Gui/Backend/GlfwWindow.cs
+++ b/Gui/Backend/GlfwWindow.cs
@@ -32,6 +32,34 @@ internal class GlfwWindow : IDisposable
         GLFW.SwapInterval(enabled ? 1 : 0);
     }
 
+    public (int width, int height) GetSize()
+    {
+        MakeContextCurrent();
+        int width = 0, height = 0;
+        GLFW.GetWindowSize(Handle, ref width, ref height);
+        return (width, height);
+    }
+
+    public void SetSize(int w, int h)
+    {
+        MakeContextCurrent();
+        GLFW.SetWindowSize(Handle, w, h);
+    }
+
+    public (int x, int y) GetPos()
+    {
+        MakeContextCurrent();
+        int x = 0, y = 0;
+        GLFW.GetWindowPos(Handle, ref x, ref y);
+        return (x, y);
+    }
+
+    public void SetPos(int w, int h)
+    {
+        MakeContextCurrent();
+        GLFW.SetWindowPos(Handle, w, h);
+    }
+
     public void MakeContextCurrent() => GLFW.MakeContextCurrent(Handle);
 
     public bool ShouldClose => GLFW.WindowShouldClose(Handle) == 1;

--- a/Gui/Backend/ImGuiController.cs
+++ b/Gui/Backend/ImGuiController.cs
@@ -48,6 +48,7 @@ internal class ImGuiController : IDisposable
 
     public void NewFrame()
     {
+        _window.MakeContextCurrent();
         ImGuiImplOpenGL3.NewFrame();
         ImGuiImplGLFW.NewFrame();
         ImGui.NewFrame();

--- a/Gui/Data/DebugFramer.cs
+++ b/Gui/Data/DebugFramer.cs
@@ -9,7 +9,7 @@ public class DebugFramer
     private readonly Subscriber<Debug.Logging.Entry> _logSubscriber = Hub.Logs.Subscribe(Mode.All);
     private readonly Subscriber<Debug.Drawing.Command> _drawSubscriber = Hub.Draws.Subscribe(Mode.All);
     private readonly Subscriber<Debug.Plotting.Command> _plotSubscriber = Hub.Plots.Subscribe(Mode.All);
-    
+
     private readonly Subscriber<Debug.Frame> _frameSubscriber = Hub.Frames.Subscribe(Mode.All);
 
     public Dictionary<string, ModuleDebugFramer> Modules { get; } = [];
@@ -41,19 +41,52 @@ public class DebugFramer
 
         while (_logSubscriber.Reader.TryRead(out var log))
         {
-            GetOrCreateModuleFramer(log.Meta.ModuleName).OnLog(log);
+            if (log.IsEmpty)
+            {
+                foreach (var module in Modules.Values)
+                {
+                    module.OnLog(log);
+                }
+            }
+            else
+            {
+                GetOrCreateModuleFramer(log.Meta.ModuleName).OnLog(log);
+            }
+
             dirty = true;
         }
-        
+
         while (_drawSubscriber.Reader.TryRead(out var draw))
         {
-            GetOrCreateModuleFramer(draw.Meta.ModuleName).OnDraw(draw);
+            if (draw.IsEmpty)
+            {
+                foreach (var module in Modules.Values)
+                {
+                    module.OnDraw(draw);
+                }
+            }
+            else
+            {
+                GetOrCreateModuleFramer(draw.Meta.ModuleName).OnDraw(draw);
+            }
+
             dirty = true;
         }
 
         while (_plotSubscriber.Reader.TryRead(out var plot))
         {
-            GetOrCreateModuleFramer(plot.Meta.ModuleName).OnPlot(plot);
+            if (plot.IsEmpty)
+            {
+                foreach (var module in Modules.Values)
+                {
+                    module.OnPlot(plot);
+                }
+            }
+            else
+            {
+                GetOrCreateModuleFramer(plot.Meta.ModuleName).OnPlot(plot);
+            }
+
             dirty = true;
         }
 

--- a/Gui/Data/ModuleDebugFramer.cs
+++ b/Gui/Data/ModuleDebugFramer.cs
@@ -128,8 +128,12 @@ public class ModuleDebugFramer
             // assignable, let's remove it from the queue
             _unassignedLogs.Dequeue();
 
-            fillFrame.Logs.Add(log);
-            AddToMetaTree(log.Meta, MetaTreeItem.ItemType.Log);
+            if (!log.IsEmpty)
+            {
+                fillFrame.Logs.Add(log);
+                AddToMetaTree(log.Meta, MetaTreeItem.ItemType.Log);
+            }
+
             _latestAssignedLogTimestamp = log.Timestamp;
         }
 
@@ -153,8 +157,12 @@ public class ModuleDebugFramer
             // assignable, let's remove it from the queue
             _unassignedDraws.Dequeue();
 
-            fillFrame.Draws.Add(draw);
-            AddToMetaTree(draw.Meta, MetaTreeItem.ItemType.Draw);
+            if (!draw.IsEmpty)
+            {
+                fillFrame.Draws.Add(draw);
+                AddToMetaTree(draw.Meta, MetaTreeItem.ItemType.Draw);
+            }
+
             _latestAssignedDrawTimestamp = draw.Timestamp;
         }
 
@@ -178,13 +186,19 @@ public class ModuleDebugFramer
             // assignable, let's remove it from the queue
             _unassignedPlots.Dequeue();
 
-            if (!fillFrame.Plots.TryAdd(plot.Id, plot))
+            if (!plot.IsEmpty)
             {
-                Log.ZLogWarning($"Dropping duplicate plot with id {plot.Id} to frame {fillFrame.StartTimestamp}");
+                if (!fillFrame.Plots.TryAdd(plot.Id, plot))
+                {
+                    Log.ZLogWarning($"Dropping duplicate plot with id {plot.Id} to frame {fillFrame.StartTimestamp}");
+                }
+                else
+                {
+                    Plots[plot.Id] = plot.Meta;
+                    AddToMetaTree(plot.Meta, MetaTreeItem.ItemType.Plot);
+                }
             }
 
-            Plots[plot.Id] = plot.Meta;
-            AddToMetaTree(plot.Meta, MetaTreeItem.ItemType.Plot);
             _latestAssignedPlotTimestamp = plot.Timestamp;
         }
 
@@ -200,8 +214,12 @@ public class ModuleDebugFramer
         var frame = GetFillFrame(log.Timestamp);
         if (frame is not null)
         {
-            frame.Logs.Add(log); // already assignable to its frame
-            AddToMetaTree(log.Meta, MetaTreeItem.ItemType.Log);
+            if (!log.IsEmpty)
+            {
+                frame.Logs.Add(log); // already assignable to its frame
+                AddToMetaTree(log.Meta, MetaTreeItem.ItemType.Log);
+            }
+
             _latestAssignedLogTimestamp = log.Timestamp;
             SealFrames();
         }
@@ -220,8 +238,12 @@ public class ModuleDebugFramer
         var frame = GetFillFrame(draw.Timestamp);
         if (frame is not null)
         {
-            frame.Draws.Add(draw); // already assignable to its frame
-            AddToMetaTree(draw.Meta, MetaTreeItem.ItemType.Draw);
+            if (!draw.IsEmpty)
+            {
+                frame.Draws.Add(draw); // already assignable to its frame
+                AddToMetaTree(draw.Meta, MetaTreeItem.ItemType.Draw);
+            }
+
             _latestAssignedDrawTimestamp = draw.Timestamp;
             SealFrames();
         }
@@ -241,13 +263,19 @@ public class ModuleDebugFramer
         if (frame is not null)
         {
             // already assignable to its frame
-            if (!frame.Plots.TryAdd(plot.Id, plot))
+            if (!plot.IsEmpty)
             {
-                Log.ZLogWarning($"Dropping duplicate plot with id {plot.Id} to frame {frame.StartTimestamp}");
+                if (!frame.Plots.TryAdd(plot.Id, plot))
+                {
+                    Log.ZLogWarning($"Dropping duplicate plot with id {plot.Id} to frame {frame.StartTimestamp}");
+                }
+                else
+                {
+                    Plots[plot.Id] = plot.Meta;
+                    AddToMetaTree(plot.Meta, MetaTreeItem.ItemType.Plot);
+                }
             }
 
-            Plots[plot.Id] = plot.Meta;
-            AddToMetaTree(plot.Meta, MetaTreeItem.ItemType.Plot);
             _latestAssignedPlotTimestamp = plot.Timestamp;
             SealFrames();
         }

--- a/Gui/Program.cs
+++ b/Gui/Program.cs
@@ -5,11 +5,10 @@ using var userConfigs = new Config.Storage("user.toml", Config.StorageType.User)
 
 using var runner = new Tyr.Gui.Runner();
 
-// init the AI
-using var sslVisionPublisher = new Tyr.Vision.SslVisionDataPublisher();
-using var gcPublisher = new Tyr.Referee.GcDataPublisher();
-
 using var referee = new Tyr.Referee.Runner();
 using var vision = new Tyr.Vision.Runner();
+
+using var sslVisionPublisher = new Tyr.Vision.SslVisionDataPublisher();
+using var gcPublisher = new Tyr.Referee.GcDataPublisher();
 
 runner.Start();

--- a/Gui/Program.cs
+++ b/Gui/Program.cs
@@ -1,30 +1,9 @@
-﻿using Hexa.NET.ImGui;
-using Tyr.Common.Debug.Drawing;
-using Tyr.Gui.Backend;
-using Tyr.Gui.Data;
-using Tyr.Gui.Views;
-using Config = Tyr.Common.Config;
+﻿using Config = Tyr.Common.Config;
 
-Tyr.Common.Debug.ModuleContext.Current.Value = ModuleName;
 using var projectConfigs = new Config.Storage(args[0], Config.StorageType.Project);
 using var userConfigs = new Config.Storage("user.toml", Config.StorageType.User);
 
-// init the backend
-using var window = new GlfwWindow(1280, 720, "Tyr");
-using var imgui = new ImGuiController(window);
-
-Style.Apply();
-
-// init our UI stuff
-using var fontRegistry = new FontRegistry();
-
-var framer = new DebugFramer();
-var filter = new DebugFilter(framer);
-var log = new LogView(framer, filter);
-var field = new FieldView(framer, filter);
-var plots = new PlotView(framer, filter);
-var control = new PlaybackControl(framer);
-var configs = new ConfigsView();
+using var runner = new Tyr.Gui.Runner();
 
 // init the AI
 using var sslVisionPublisher = new Tyr.Vision.SslVisionDataPublisher();
@@ -33,26 +12,4 @@ using var gcPublisher = new Tyr.Referee.GcDataPublisher();
 using var referee = new Tyr.Referee.Runner();
 using var vision = new Tyr.Vision.Runner();
 
-while (window.ShouldClose == false)
-{
-    // update
-    framer.Tick();
-    window.PollEvents();
-
-    // draw
-    window.Clear(Color.Slate950);
-    imgui.NewFrame();
-
-    ImGui.ShowDemoWindow();
-
-    configs.Draw();
-
-    control.Draw();
-    log.Draw(control.Current);
-    field.Draw(control.Current);
-    plots.Draw(control.Current);
-    filter.Draw();
-
-    imgui.Render();
-    window.SwapBuffers();
-}
+runner.Start();

--- a/Gui/Program.cs
+++ b/Gui/Program.cs
@@ -3,9 +3,11 @@ using Tyr.Common.Debug.Drawing;
 using Tyr.Gui.Backend;
 using Tyr.Gui.Data;
 using Tyr.Gui.Views;
+using Config = Tyr.Common.Config;
 
 Tyr.Common.Debug.ModuleContext.Current.Value = ModuleName;
-Tyr.Common.Config.Storage.Initialize(args[0]);
+using var projectConfigs = new Config.Storage(args[0], Config.StorageType.Project);
+using var userConfigs = new Config.Storage("user.toml", Config.StorageType.User);
 
 // init the backend
 using var window = new GlfwWindow(1280, 720, "Tyr");

--- a/Gui/Rendering/DrawableRenderer.cs
+++ b/Gui/Rendering/DrawableRenderer.cs
@@ -18,6 +18,8 @@ internal class DrawableRenderer
 
     internal void Draw(IReadOnlyList<Command> commands, DebugFilter? filter)
     {
+        if (commands.Count == 0) return;
+
         Log.ZLogTrace($"Drawing {commands.Count} items");
 
         _drawList = ImGui.GetWindowDrawList();

--- a/Gui/Runner.cs
+++ b/Gui/Runner.cs
@@ -1,4 +1,5 @@
 ﻿using Hexa.NET.ImGui;
+using Tyr.Common.Config;
 using Tyr.Common.Debug.Drawing;
 using Tyr.Common.Runner;
 using Tyr.Gui.Backend;
@@ -7,8 +8,13 @@ using Tyr.Gui.Views;
 
 namespace Tyr.Gui;
 
-public sealed class Runner : IDisposable
+[Configurable]
+public sealed partial class Runner : IDisposable
 {
+    [ConfigEntry(StorageType.User)] private static bool VSync { get; set; } = true;
+    [ConfigEntry(StorageType.User)] private static int WindowWidth { get; set; } = 1280;
+    [ConfigEntry(StorageType.User)] private static int WindowHeight { get; set; } = 720;
+
     private readonly RunnerSync _runner;
 
     // backend
@@ -28,8 +34,8 @@ public sealed class Runner : IDisposable
     public Runner()
     {
         // init the backend
-        _window = new GlfwWindow(1280, 720, "Tyr");
-        //window.SetVSync(false);
+        _window = new GlfwWindow(WindowWidth, WindowHeight, "Tyr");
+        _window.SetVSync(VSync);
 
         _imgui = new ImGuiController(_window);
 
@@ -48,6 +54,14 @@ public sealed class Runner : IDisposable
 
         // and the runner
         _runner = new RunnerSync(Tick, 0, ModuleName);
+
+        Configurable.OnUpdated += OnConfigsChanged;
+    }
+
+    private void OnConfigsChanged(StorageType storageType)
+    {
+        _window.SetVSync(VSync);
+        _window.SetSize(WindowWidth, WindowHeight);
     }
 
     public void Start()

--- a/Gui/Runner.cs
+++ b/Gui/Runner.cs
@@ -1,0 +1,96 @@
+﻿using Hexa.NET.ImGui;
+using Tyr.Common.Debug.Drawing;
+using Tyr.Common.Runner;
+using Tyr.Gui.Backend;
+using Tyr.Gui.Data;
+using Tyr.Gui.Views;
+
+namespace Tyr.Gui;
+
+public sealed class Runner : IDisposable
+{
+    private readonly RunnerSync _runner;
+
+    // backend
+    private readonly GlfwWindow _window;
+    private readonly ImGuiController _imgui;
+    private readonly FontRegistry _fonts;
+
+    // views
+    private readonly DebugFramer _framer;
+    private readonly DebugFilter _filter;
+    private readonly LogView _log;
+    private readonly FieldView _field;
+    private readonly PlotView _plots;
+    private readonly PlaybackControl _control;
+    private readonly ConfigsView _configs;
+
+    public Runner()
+    {
+        // init the backend
+        _window = new GlfwWindow(1280, 720, "Tyr");
+        //window.SetVSync(false);
+
+        _imgui = new ImGuiController(_window);
+
+        Style.Apply();
+
+        _fonts = new FontRegistry();
+
+        // init our UI views
+        _framer = new DebugFramer();
+        _filter = new DebugFilter(_framer);
+        _log = new LogView(_framer, _filter);
+        _field = new FieldView(_framer, _filter);
+        _plots = new PlotView(_framer, _filter);
+        _control = new PlaybackControl(_framer);
+        _configs = new ConfigsView();
+
+        // and the runner
+        _runner = new RunnerSync(Tick, 0, ModuleName);
+    }
+
+    public void Start()
+    {
+        _runner.StartOnCurrentThread();
+    }
+
+    private void Tick()
+    {
+        // update
+        _framer.Tick();
+        _window.PollEvents();
+
+        // draw
+        _window.Clear(Color.Slate950);
+        _imgui.NewFrame();
+
+        ImGui.ShowDemoWindow();
+
+        _configs.Draw();
+
+        _control.Draw();
+        _log.Draw(_control.Current);
+        _field.Draw(_control.Current);
+        _plots.Draw(_control.Current);
+        _filter.Draw();
+
+        _imgui.Render();
+        _window.SwapBuffers();
+
+        if (_window.ShouldClose)
+        {
+            _runner.Stop();
+        }
+    }
+
+    public void Dispose()
+    {
+        _window.Dispose();
+        _imgui.Dispose();
+        _fonts.Dispose();
+        _filter.Dispose();
+        _log.Dispose();
+        _field.Dispose();
+    }
+}

--- a/Gui/Runner.cs
+++ b/Gui/Runner.cs
@@ -20,7 +20,7 @@ public sealed partial class Runner : IDisposable
     [ConfigEntry(StorageType.User, false)] private static int WindowPosX { get; set; }
     [ConfigEntry(StorageType.User, false)] private static int WindowPosY { get; set; }
 
-    [ConfigEntry(StorageType.User, false)] private static bool WindowMaximized { get; set; } = false;
+    [ConfigEntry(StorageType.User, false)] private static bool WindowMaximized { get; set; }
 
     private readonly RunnerSync _runner;
 

--- a/Gui/Views/ConfigsView.cs
+++ b/Gui/Views/ConfigsView.cs
@@ -167,6 +167,8 @@ public class ConfigsView
             ImGui.EndTooltip();
         }
 
+        ImGui.BeginDisabled(!field.Editable);
+
         // Reset button
         ImGui.TableNextColumn();
         if (ImGui.SmallButton($"{IconFonts.FontAwesome6.RotateLeft}"))
@@ -188,6 +190,8 @@ public class ConfigsView
         // Value
         ImGui.TableNextColumn();
         DrawFieldEditor(field);
+
+        ImGui.EndDisabled();
 
         ImGui.PopID();
     }

--- a/Gui/Views/ConfigsView.cs
+++ b/Gui/Views/ConfigsView.cs
@@ -119,8 +119,9 @@ public class ConfigsView
         if (nodeOpen)
         {
             var ownFilterMatch = _filter.PassFilter(configurable.Type.Name);
-            if (ImGui.BeginTable("fields", 3, ImGuiTableFlags.BordersH))
+            if (ImGui.BeginTable("fields", 4, ImGuiTableFlags.BordersH))
             {
+                ImGui.TableSetupColumn("icon", ImGuiTableColumnFlags.WidthFixed, 15f);
                 ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch, 1.0f);
                 ImGui.TableSetupColumn("Reset", ImGuiTableColumnFlags.WidthFixed, 15f);
                 ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch, 1.5f);
@@ -144,6 +145,21 @@ public class ConfigsView
     private void DrawField(ConfigEntry field)
     {
         ImGui.PushID(field.Name);
+
+        // Icon
+        ImGui.TableNextColumn();
+        var icon = field.StorageType switch
+        {
+            StorageType.Project => IconFonts.FontAwesome6.Database,
+            StorageType.User => IconFonts.FontAwesome6.LaptopFile,
+            _ => IconFonts.FontAwesome6.Question,
+        };
+        ImGui.TextUnformatted(icon);
+
+        if (ImGui.IsItemHovered(ImGuiHoveredFlags.ForTooltip))
+        {
+            ImGui.SetTooltip($"{field.StorageType} config");
+        }
 
         // Name
         ImGui.TableNextColumn();

--- a/Gui/Views/ConfigsView.cs
+++ b/Gui/Views/ConfigsView.cs
@@ -198,40 +198,46 @@ public class ConfigsView
         switch (field.Value)
         {
             case int intValue:
-                if (ImGui.InputInt("", ref intValue))
+                ImGui.InputInt("", ref intValue);
+                if ((ImGui.IsItemEdited() && ImGui.IsItemClicked()) // changed using the +/- buttons
+                    || ImGui.IsItemDeactivatedAfterEdit()) // or using the text field
                 {
-                    field.Value = (intValue);
+                    field.Value = intValue;
                 }
 
                 break;
 
             case float floatValue:
-                if (ImGui.InputFloat("", ref floatValue))
+                ImGui.InputFloat("", ref floatValue);
+                if (ImGui.IsItemDeactivatedAfterEdit())
                 {
-                    field.Value = (floatValue);
+                    field.Value = floatValue;
                 }
 
                 break;
 
             case double doubleValue:
                 var tmpValue = (float)doubleValue;
-                if (ImGui.InputFloat("", ref tmpValue))
+                ImGui.InputFloat("", ref tmpValue);
+                if (ImGui.IsItemDeactivatedAfterEdit())
                 {
-                    field.Value = ((double)tmpValue);
+                    field.Value = (double)tmpValue;
                 }
 
                 break;
 
             case bool boolValue:
-                if (ImGui.Checkbox("", ref boolValue))
+                ImGui.Checkbox("", ref boolValue);
+                if (ImGui.IsItemDeactivatedAfterEdit())
                 {
-                    field.Value = (boolValue);
+                    field.Value = boolValue;
                 }
 
                 break;
 
             case string stringValue:
-                if (ImGui.InputText("", ref stringValue, 256))
+                ImGui.InputText("", ref stringValue, 256);
+                if (ImGui.IsItemDeactivatedAfterEdit())
                 {
                     field.Value = stringValue;
                 }
@@ -239,15 +245,22 @@ public class ConfigsView
                 break;
 
             case Address addressValue:
+                var changed = false;
                 var ip = addressValue.Ip;
                 var port = addressValue.Port;
                 ImGui.InputText("##ip", ref ip, 256, ImGuiInputTextFlags.CharsDecimal);
+                changed |= ImGui.IsItemDeactivatedAfterEdit();
                 ImGui.SameLine();
                 ImGui.Text(":");
                 ImGui.SameLine();
                 ImGui.InputInt("##port", ref port);
+                changed |= ImGui.IsItemDeactivatedAfterEdit();
 
-                field.Value = new Address { Ip = ip, Port = port };
+                if (changed)
+                {
+                    field.Value = new Address { Ip = ip, Port = port };
+                }
+
                 break;
 
             case Enum enumValue:
@@ -261,7 +274,8 @@ public class ConfigsView
                 }
 
                 var index = Array.IndexOf(enumData.Values, enumValue);
-                if (ImGui.Combo("", ref index, enumData.Names, enumData.Names.Length))
+                ImGui.Combo("", ref index, enumData.Names, enumData.Names.Length);
+                if (ImGui.IsItemDeactivatedAfterEdit())
                 {
                     field.Value = enumData.Values.GetValue(index)!;
                 }

--- a/Gui/Views/ConfigsView.cs
+++ b/Gui/Views/ConfigsView.cs
@@ -106,10 +106,10 @@ public class ConfigsView
             ImGui.TextColored(Color.Zinc400, $"{configurable.Type.FullName}");
             ImGui.PopFont();
 
-            if (!string.IsNullOrEmpty(configurable.Comment))
+            if (!string.IsNullOrEmpty(configurable.Description))
             {
                 ImGui.PushTextWrapPos(ImGui.GetFontSize() * 15.0f);
-                ImGui.TextUnformatted(configurable.Comment);
+                ImGui.TextUnformatted(configurable.Description);
                 ImGui.PopTextWrapPos();
             }
 
@@ -157,10 +157,10 @@ public class ConfigsView
             ImGui.TextColored(Color.Zinc400, $"{field.Type.FullName}");
             ImGui.PopFont();
 
-            if (!string.IsNullOrEmpty(field.Comment))
+            if (!string.IsNullOrEmpty(field.Description))
             {
                 ImGui.PushTextWrapPos(ImGui.GetFontSize() * 15.0f);
-                ImGui.TextUnformatted(field.Comment);
+                ImGui.TextUnformatted(field.Description);
                 ImGui.PopTextWrapPos();
             }
 

--- a/Gui/Views/LogView.cs
+++ b/Gui/Views/LogView.cs
@@ -65,7 +65,6 @@ public sealed partial class LogView(DebugFramer debugFramer, DebugFilter filter)
                     {
                         if (!filter.IsEnabled(log.Meta)) continue;
                         if (log.Level < LogLevel) continue;
-                        if (string.IsNullOrWhiteSpace(log.Message)) continue;
 
                         _filterTested += 1;
                         if (!_filter.PassFilter(log.Message) &&

--- a/Gui/Views/LogView.cs
+++ b/Gui/Views/LogView.cs
@@ -190,7 +190,7 @@ public sealed partial class LogView(DebugFramer debugFramer, DebugFilter filter)
         if (ImGui.Combo("Level", ref index, names, names.Length))
         {
             LogLevel = Debug.EnumCache<LogLevel>.GetByIndex(index);
-            Configurable.OnChanged(StorageType.User);
+            Configurable.MarkChanged(StorageType.User);
         }
 
         ImGui.PopStyleColor();

--- a/Gui/Views/LogView.cs
+++ b/Gui/Views/LogView.cs
@@ -13,7 +13,7 @@ namespace Tyr.Gui.Views;
 [Configurable]
 public sealed partial class LogView(DebugFramer debugFramer, DebugFilter filter) : IDisposable
 {
-    [ConfigEntry] private static LogLevel LogLevel { get; set; } = LogLevel.Debug;
+    [ConfigEntry(StorageType.User)] private static LogLevel LogLevel { get; set; } = LogLevel.Debug;
 
     private Utf8ValueStringBuilder _stringBuilder = ZString.CreateUtf8StringBuilder();
 
@@ -191,7 +191,7 @@ public sealed partial class LogView(DebugFramer debugFramer, DebugFilter filter)
         if (ImGui.Combo("Level", ref index, names, names.Length))
         {
             LogLevel = Debug.EnumCache<LogLevel>.GetByIndex(index);
-            Configurable.OnChanged();
+            Configurable.OnChanged(StorageType.User);
         }
 
         ImGui.PopStyleColor();

--- a/Gui/Views/PlotView.cs
+++ b/Gui/Views/PlotView.cs
@@ -107,8 +107,6 @@ public partial class PlotView(DebugFramer debugFramer, DebugFilter filter)
         {
             foreach (var (plotId, plotMeta) in framer.Plots)
             {
-                if (string.IsNullOrWhiteSpace(plotId)) continue;
-
                 if (!filter.IsEnabled(plotMeta)) continue;
 
                 _filterTested += 1;

--- a/Referee/GcDataPublisher.cs
+++ b/Referee/GcDataPublisher.cs
@@ -6,13 +6,18 @@ using Gc = Tyr.Common.Data.Ssl.Gc;
 namespace Tyr.Referee;
 
 [Configurable]
-public partial class GcDataPublisher : IDisposable
+public sealed partial class GcDataPublisher : IDisposable
 {
     [ConfigEntry] private static Address GcAddress { get; set; } = new() { Ip = "224.5.23.1", Port = 10003 };
 
-    private readonly UdpReceiver<Gc.Referee> _udpReceiver = new(GcAddress, OnData, ModuleName);
+    private readonly UdpReceiver<Gc.Referee> _udpReceiver;
 
-    private static void OnData(Gc.Referee data)
+    public GcDataPublisher()
+    {
+        _udpReceiver = new UdpReceiver<Gc.Referee>(GcAddress, OnData, "Gc");
+    }
+
+    private void OnData(Gc.Referee data)
     {
         Hub.RawReferee.Publish(data);
     }

--- a/Referee/Runner.cs
+++ b/Referee/Runner.cs
@@ -28,8 +28,6 @@ public sealed class Runner : IDisposable
 
     private async Task Tick(CancellationToken token)
     {
-        _runner.NewDebugFrame();
-
         await Task.WhenAny(ReceiveGc(token), ReceiveVision(token));
 
         if (_referee.Process(_vision, _gc))

--- a/Vision/Camera.cs
+++ b/Vision/Camera.cs
@@ -68,8 +68,6 @@ public partial class Camera(uint id)
 
         _frameTimeEstimator.AddSample(frame.FrameNumber, frame.CaptureTime);
 
-        Log.ZLogTrace($"Camera {Id} FPS: {Fps:F2}");
-
         Plot.Plot($"cam[{Id}] fps", Fps, "fps");
 
         // detections

--- a/Vision/Runner.cs
+++ b/Vision/Runner.cs
@@ -26,8 +26,6 @@ public sealed partial class Runner : IDisposable
 
     private void Tick()
     {
-        _runner.NewDebugFrame();
-
         FieldSize? fieldSize = _fieldSizeSubscriber.TryGetLatest(out var f) ? f : null;
 
         _vision.Process(

--- a/Vision/SslVisionDataPublisher.cs
+++ b/Vision/SslVisionDataPublisher.cs
@@ -14,14 +14,15 @@ public sealed partial class SslVisionDataPublisher : IDisposable
 
     private static Address Address => UseSimulator ? SimulatorAddress : VisionAddress;
 
-    private readonly UdpReceiver<WrapperPacket> _udpReceiver = new(Address, OnData, ModuleName);
+    private readonly UdpReceiver<WrapperPacket> _udpReceiver;
 
     public SslVisionDataPublisher()
     {
+        _udpReceiver = new UdpReceiver<WrapperPacket>(Address, OnData, "SslVision");
         Log.ZLogInformation($"SSL Vision Data publisher initialized on {Address}.");
     }
 
-    private static void OnData(WrapperPacket data)
+    private void OnData(WrapperPacket data)
     {
         if (data.Detection != null)
             Hub.RawDetection.Publish(data.Detection);

--- a/Vision/SslVisionDataPublisher.cs
+++ b/Vision/SslVisionDataPublisher.cs
@@ -8,14 +8,17 @@ namespace Tyr.Vision;
 [Configurable]
 public sealed partial class SslVisionDataPublisher : IDisposable
 {
-    [ConfigEntry] public static Address VisionAddress { get; set; } = new() { Ip = "224.5.23.2", Port = 10006 };
-    [ConfigEntry] public static Address VisionSimAddress { get; set; } = new() { Ip = "224.5.23.2", Port = 10025 };
+    [ConfigEntry] private static Address VisionAddress { get; set; } = new() { Ip = "224.5.23.2", Port = 10006 };
+    [ConfigEntry] private static Address SimulatorAddress { get; set; } = new() { Ip = "224.5.23.2", Port = 10025 };
+    [ConfigEntry(StorageType.User)] private static bool UseSimulator { get; set; } = false;
 
-    private readonly UdpReceiver<WrapperPacket> _udpReceiver = new(VisionSimAddress, OnData, ModuleName);
+    private static Address Address => UseSimulator ? SimulatorAddress : VisionAddress;
+
+    private readonly UdpReceiver<WrapperPacket> _udpReceiver = new(Address, OnData, ModuleName);
 
     public SslVisionDataPublisher()
     {
-        Log.ZLogInformation($"SSL Vision Data publisher initialized on {VisionSimAddress}.");
+        Log.ZLogInformation($"SSL Vision Data publisher initialized on {Address}.");
     }
 
     private static void OnData(WrapperPacket data)

--- a/Vision/Vision.cs
+++ b/Vision/Vision.cs
@@ -59,6 +59,8 @@ public sealed partial class Vision
 
         foreach (var camera in _cameras.Values)
         {
+            Log.ZLogTrace($"Camera {camera.Id} FPS: {camera.Fps:F2}");
+
             DrawRobots(camera);
             DrawBalls(camera);
         }


### PR DESCRIPTION
This pull request introduces several improvements and features:

- Established clear distinction between per-user and project-wide configuration types.
- Added an icon for configuration types in the GUI.
- Restored the window state when reopening the application.
- Introduced non-editable configuration entries for programmatically set values.
- Prevented serialization of empty configurables for cleaner data handling.
- Updated GUI updates to occur only after editing input operations are finished.
- Refactored GUI runner functionality into a separate class for better modularity.
- Automated the creation of debug frames for each runner, adding stability by using distinct module names.
- Enhanced handling for empty debug entry publishing.