### PR TITLE
Cleanup obsolete code in Sender/Nrf.cs

### DIFF
--- a/Sender/Nrf.cs
+++ b/Sender/Nrf.cs
@@ -16,18 +16,9 @@ public sealed partial class Nrf : ISender // TODO: this is untested, test at the
     private Span<byte> Buffer => _udp.GetBuffer();
     private int _buffIdx;
 
-    // TODO: probably not needed anymore
-    private int _startup = 5;
-
     public bool Send(CommandsWrapper commands)
     {
         if (!Enabled) return false;
-
-        if (_startup > 0)
-        {
-            _startup--;
-            return false;
-        }
 
         foreach (var command in commands.Commands)
         {


### PR DESCRIPTION
Cleaned up obsolete code in `Sender/Nrf.cs` by removing the `_startup` field and its corresponding logic in the `Send` method. This logic originally implemented a 5-tick startup delay but was marked as no longer needed. The explicit empty constructor mentioned in the original task was already absent, having been replaced by an implicit default constructor.

---
*PR created automatically by Jules for task [8374831075867437450](https://jules.google.com/task/8374831075867437450) started by @lordhippo*