### PR TITLE
⚡ Remove redundant ToList materialization in Sender

### DIFF
--- a/Sender/ZmqRobotSender.cs
+++ b/Sender/ZmqRobotSender.cs
@@ -52,7 +52,7 @@ public sealed partial class ZmqRobotSender : ISender
         }
 
         // Clean up timed-out robots
-        var toRemove = _senders.Keys.Where(id => !activeIds.Contains(id)).ToList();
+        var toRemove = _senders.Keys.Where(id => !activeIds.Contains(id));
         foreach (var id in toRemove)
         {
             if (_senders.TryRemove(id, out var sender))


### PR DESCRIPTION
💡 **What:** The optimization implemented
Removed redundant `.ToList()` calls when iterating over `ConcurrentDictionary.Keys` after a `Where` filter in `ZmqRobotSender.cs` and `RobotStatusPublisher.cs`.

🎯 **Why:** The performance problem it solves
The `.ToList()` call creates an unnecessary intermediate list allocation and copy of the keys. In .NET, `ConcurrentDictionary.Keys` already provides a thread-safe snapshot. When combined with a LINQ `Where` clause, the result can be iterated directly in a `foreach` loop without further materialization, saving memory allocations and CPU cycles in the command/status update loops.

📊 **Measured Improvement:**
Establishing a precise baseline in this environment was impractical due to build timeouts. However, this is a well-known C# performance best practice. By removing `.ToList()`, we eliminate an $O(N)$ allocation and an $O(N)$ copy of the filtered keys on every connection management cycle (where $N$ is the number of disconnected robots). In high-frequency loops or environments with many robots, this reduces GC pressure and improves overall efficiency.

---
*PR created automatically by Jules for task [9581517209086109354](https://jules.google.com/task/9581517209086109354) started by @lordhippo*