### PR TITLE
Rename AppendDemoData method to AppendHeartbeat

### DIFF
--- a/Sender/Nrf.cs
+++ b/Sender/Nrf.cs
@@ -35,7 +35,7 @@ public sealed partial class Nrf : ISender // TODO: this is untested, test at the
             else AppendCommand(command);
         }
 
-        AppendDemoData();
+        AppendHeartbeat();
 
         Log.ZLogTrace($"Sending {_buffIdx}  bytes to {Address}");
 
@@ -105,8 +105,7 @@ public sealed partial class Nrf : ISender // TODO: this is untested, test at the
         AppendByte(0x00);
     }
 
-    // TODO: rename
-    private void AppendDemoData()
+    private void AppendHeartbeat()
     {
         AppendByte(25);
         AppendByte(0x0A);


### PR DESCRIPTION
Renamed the `AppendDemoData` method to `AppendHeartbeat` in `Sender/Nrf.cs` to better reflect its purpose as a heartbeat signal for the NRF radio protocol. Updated the call site and removed the legacy TODO comment.

---
*PR created automatically by Jules for task [7559329907144749194](https://jules.google.com/task/7559329907144749194) started by @lordhippo*