### PR TITLE
⚡ Bolt: eliminate LINQ allocations in Ai.UpdateContext and Ai.Process

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-12 - Avoid LINQ in per-frame hot path
+**Learning:** LINQ methods like `Where` and `FirstOrDefault` implicitly allocate enumerators and closures when capturing state (e.g., `Context.Color` or lambda expressions). In a 100Hz real-time loop like `Ai.UpdateContext()` and `Ai.Process()`, these allocations stack up quickly, causing significant GC pressure and potential micro-stutters.
+**Action:** Replace `LINQ` operations with manual `foreach` or `for` loops in the per-frame hot path to achieve zero-allocation data iteration.

--- a/Soccer/Ai.cs
+++ b/Soccer/Ai.cs
@@ -61,22 +61,25 @@ public partial class Ai
             robot.Filtered = robot.Filtered with { Quality = 0f };
         }
 
-        foreach (var filtered in vision.Robots.Where(robot => robot.Id.Team == Context.Color))
-        {
-            var id = (int)filtered.Id.Id!.Value;
-            var predicted = filtered.Extrapolate(now, CommandHistory(id));
-            Context.OwnRobots[id].Filtered = predicted;
-
-            Draw.DrawRobot(predicted.State.Position, predicted.State.Angle, filtered.Id, options: Options.Outline());
-        }
-
+        // Bolt: eliminates ~2 enumerator & closure allocs/frame by avoiding LINQ Where()
         Context.OppRobots.Clear();
-        foreach (var filtered in vision.Robots.Where(robot => robot.Id.Team != Context.Color))
+        foreach (var filtered in vision.Robots)
         {
-            var predicted = filtered.Extrapolate(now);
-            Context.OppRobots.Add(predicted);
+            if (filtered.Id.Team == Context.Color)
+            {
+                var id = (int)filtered.Id.Id!.Value;
+                var predicted = filtered.Extrapolate(now, CommandHistory(id));
+                Context.OwnRobots[id].Filtered = predicted;
 
-            Draw.DrawRobot(predicted.State.Position, predicted.State.Angle, filtered.Id, options: Options.Outline());
+                Draw.DrawRobot(predicted.State.Position, predicted.State.Angle, filtered.Id, options: Options.Outline());
+            }
+            else
+            {
+                var predicted = filtered.Extrapolate(now);
+                Context.OppRobots.Add(predicted);
+
+                Draw.DrawRobot(predicted.State.Position, predicted.State.Angle, filtered.Id, options: Options.Outline());
+            }
         }
 
         Context.Data.Value = Context.Data.Value! with
@@ -160,7 +163,17 @@ public partial class Ai
             return;
         }
 
-        var firstRobot = Context.OwnRobots.FirstOrDefault(r => r.Seen);
+        // Bolt: eliminates ~1 enumerator & closure alloc/frame by avoiding LINQ FirstOrDefault()
+        Robot.Robot? firstRobot = null;
+        foreach (var r in Context.OwnRobots)
+        {
+            if (r.Seen)
+            {
+                firstRobot = r;
+                break;
+            }
+        }
+
         if (firstRobot != null)
         {
             if (Context.Referee.Running())


### PR DESCRIPTION
💡 **What:** Replaced `LINQ` operations (`vision.Robots.Where` and `Context.OwnRobots.FirstOrDefault`) with manual `foreach` loops in the per-frame `Soccer.Ai` hot path.
🎯 **Why:** LINQ queries like `Where` and `FirstOrDefault` with captured state implicitly allocate enumerators and closures on the heap. Running these at ~100Hz generates significant GC pressure and stuttering for the real-time AI loop.
📊 **Impact:** Eliminates ~3 allocations per frame at 100Hz = ~300 allocs/sec removed from the hot path.
🔬 **Measurement:** Verify savings via `dotnet-counters monitor --counters System.Runtime[gen-0-gc-count,alloc-rate]`.

---
*PR created automatically by Jules for task [17051810251548119282](https://jules.google.com/task/17051810251548119282) started by @lordhippo*