### PR TITLE
⚡ Bolt: Eliminate role assignment LINQ and collections allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-04-12 - Avoid LINQ in per-frame hot path
 **Learning:** LINQ methods like `Where` and `FirstOrDefault` implicitly allocate enumerators and closures when capturing state (e.g., `Context.Color` or lambda expressions). In a 100Hz real-time loop like `Ai.UpdateContext()` and `Ai.Process()`, these allocations stack up quickly, causing significant GC pressure and potential micro-stutters.
 **Action:** Replace `LINQ` operations with manual `foreach` or `for` loops in the per-frame hot path to achieve zero-allocation data iteration.
+
+## 2026-10-27 - Double-buffering to eliminate per-frame dictionary allocations
+**Learning:** When a mapping is built in the hot path and needs to be compared against the previous frame (like tracking role or tactic assignments), constructing a `new Dictionary<int, T>()` on every frame is a massive allocation hotspot.
+**Action:** Use a double-buffering approach. Pre-allocate two dictionaries (e.g., `_roleMapping` and `_nextRoleMapping`), clear `_nextRoleMapping` at the start of the frame, build the current frame mapping into it, perform any comparisons against `_roleMapping`, and finally swap them: `(_roleMapping, _nextRoleMapping) = (_nextRoleMapping, _roleMapping)`.

--- a/Soccer/Ai.cs
+++ b/Soccer/Ai.cs
@@ -24,7 +24,11 @@ public partial class Ai
     private readonly ManualControlState _manualControl;
 
     private Dictionary<int, Role.IRole?> _roleMapping = [];
+    private Dictionary<int, Role.IRole?> _nextRoleMapping = [];
     private Dictionary<int, ITactic?> _tacticMapping = [];
+
+    private readonly List<Role.IRole> _activeRoles = [];
+    private static readonly Role.Attacker _attackerRole = new();
 
     internal Ai(ManualControlState manualControl)
     {
@@ -166,24 +170,39 @@ public partial class Ai
         }
 
         // this resembles a play emitting a role
-        var roles = new List<Role.IRole>();
+        // Bolt: reuse pre-allocated list to prevent `new List<IRole>()` alloc/frame
+        _activeRoles.Clear();
         if (Context.Referee.Running())
         {
-            roles.Add(new Role.Attacker());
+            _activeRoles.Add(_attackerRole);
         }
 
-        // then the role assigner maps the roles to robots
-        var newRoleMapping = new Dictionary<int, Role.IRole?>();
-        foreach (var role in roles.OrderByDescending(r => r.Importance))
+        // Sort roles by importance descending (allocation-free sort)
+        _activeRoles.Sort(static (r1, r2) => r2.Importance.CompareTo(r1.Importance));
+
+        // Bolt: eliminate LINQ Where/OrderBy/FirstOrDefault allocation chains
+        _nextRoleMapping.Clear();
+        foreach (var role in _activeRoles)
         {
-            var best = Context.OwnRobots
-                .Where(r => r.Seen && !newRoleMapping.ContainsKey(r.Id))
-                .OrderBy(role.CostFor)
-                .FirstOrDefault();
+            Robot.Robot? best = null;
+            var bestCost = float.MaxValue;
+
+            foreach (var r in Context.OwnRobots)
+            {
+                if (r.Seen && !_nextRoleMapping.ContainsKey(r.Id))
+                {
+                    var cost = role.CostFor(r);
+                    if (cost < bestCost)
+                    {
+                        bestCost = cost;
+                        best = r;
+                    }
+                }
+            }
 
             if (best != null)
             {
-                newRoleMapping[best.Id] = role;
+                _nextRoleMapping[best.Id] = role;
             }
         }
 
@@ -191,7 +210,7 @@ public partial class Ai
         foreach (var robot in Context.OwnRobots)
         {
             var currentRole = _roleMapping.GetValueOrDefault(robot.Id);
-            var newRole = newRoleMapping.GetValueOrDefault(robot.Id);
+            var newRole = _nextRoleMapping.GetValueOrDefault(robot.Id);
 
             if (!currentRole?.Equals(newRole) ?? newRole is not null)
             {
@@ -201,7 +220,8 @@ public partial class Ai
             }
         }
 
-        _roleMapping = newRoleMapping;
+        // Bolt: swap dictionaries to prevent `new Dictionary` allocation next frame
+        (_roleMapping, _nextRoleMapping) = (_nextRoleMapping, _roleMapping);
 
         // and execute tactics for each robot
         foreach (var robot in Context.OwnRobots)


### PR DESCRIPTION
In the `Ai.Process` loop (~100Hz), the role assignment logic was doing:
- `new List<Role.IRole>()`
- `new Role.Attacker()`
- `new Dictionary<int, Role.IRole?>()`
- LINQ `.Where(...).OrderBy(...).FirstOrDefault()`

This was creating extreme GC pressure and several allocations per frame.

By introducing class-level double-buffered dictionaries (`_roleMapping` and `_nextRoleMapping`), a class-level list `_activeRoles`, and caching the stateless `Role.Attacker`, we eliminated object creation. LINQ has also been replaced with an explicit `foreach` loop.

Savings: ~600 allocs/sec at 100Hz.

---
*PR created automatically by Jules for task [9476419200741517281](https://jules.google.com/task/9476419200741517281) started by @lordhippo*