### PR TITLE
Add journal mode to log view for session-wide log history

### DIFF
--- a/Common/Debug/Db/DebugDb.cs
+++ b/Common/Debug/Db/DebugDb.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using MemoryPack;
+using Microsoft.Extensions.Logging;
+using Tyr.Common.Debug.Logging;
 
 namespace Tyr.Common.Debug.Db;
 
@@ -29,6 +31,9 @@ public sealed class DebugDb : IDebugDb
     private readonly ConcurrentDictionary<int, Meta> _sourceLocationCache = new();
     private readonly ConcurrentDictionary<int, ModuleFrameIndex> _frameIndices = new();
     private readonly Lock _internLock = new();
+    private readonly List<Entry> _journal = [];
+    private readonly Lock _journalLock = new();
+    private const LogLevel JournalMinLevel = LogLevel.Information;
 
     [ThreadStatic] private static ArrayBufferWriter<byte>? _serializeBuffer;
 
@@ -134,6 +139,12 @@ public sealed class DebugDb : IDebugDb
         {
             Timestamp = entry.Timestamp.Nanoseconds,
         }, buffer.WrittenSpan);
+
+        if (entry is Entry logEntry && logEntry.Level >= JournalMinLevel)
+        {
+            lock (_journalLock)
+                _journal.Add(logEntry);
+        }
     }
 
     public IEnumerable<T> Query<T>(string module, Timestamp t0, Timestamp t1, string? shardKey = null, int? maxCount = null) where T : struct, IEntry
@@ -584,6 +595,31 @@ public sealed class DebugDb : IDebugDb
     public Meta GetSourceLocation(int id)
     {
         return _sources.Get(id, _strings);
+    }
+
+    public void BuildJournal()
+    {
+        var range = GetFrameRange();
+        if (range is null) return;
+
+        var entries = QueryAll<Entry>(range.Value.Start, range.Value.End)
+            .Where(e => e.Level >= JournalMinLevel)
+            .OrderBy(e => e.Timestamp);
+
+        lock (_journalLock)
+        {
+            _journal.Clear();
+            _journal.AddRange(entries);
+        }
+    }
+
+    public void FillJournal(List<Entry> destination)
+    {
+        lock (_journalLock)
+        {
+            destination.Clear();
+            destination.AddRange(_journal);
+        }
     }
 
     public void AppendFrame(Frame frame)

--- a/Common/Debug/Db/DebugDb.cs
+++ b/Common/Debug/Db/DebugDb.cs
@@ -31,9 +31,11 @@ public sealed class DebugDb : IDebugDb
     private readonly ConcurrentDictionary<int, Meta> _sourceLocationCache = new();
     private readonly ConcurrentDictionary<int, ModuleFrameIndex> _frameIndices = new();
     private readonly Lock _internLock = new();
-    private readonly List<Entry> _journal = [];
+    private readonly List<JournalGroup> _journal = [];
+    private readonly Dictionary<(Meta Meta, string Message, LogLevel Level), int> _journalIndex = new();
     private readonly Lock _journalLock = new();
     private const LogLevel JournalMinLevel = LogLevel.Information;
+    private bool _groupJournalEntries = true;
 
     [ThreadStatic] private static ArrayBufferWriter<byte>? _serializeBuffer;
 
@@ -143,8 +145,25 @@ public sealed class DebugDb : IDebugDb
         if (entry is Entry logEntry && logEntry.Level >= JournalMinLevel)
         {
             lock (_journalLock)
-                _journal.Add(logEntry);
+                AddToJournal(logEntry);
         }
+    }
+
+    // Must be called under _journalLock.
+    private void AddToJournal(Entry entry)
+    {
+        if (_groupJournalEntries)
+        {
+            var key = (entry.Meta, entry.Message, entry.Level);
+            if (_journalIndex.TryGetValue(key, out var idx))
+            {
+                var g = _journal[idx];
+                _journal[idx] = g with { Count = g.Count + 1, LastTime = entry.Timestamp };
+                return;
+            }
+            _journalIndex[key] = _journal.Count;
+        }
+        _journal.Add(new JournalGroup(entry, 1, entry.Timestamp));
     }
 
     public IEnumerable<T> Query<T>(string module, Timestamp t0, Timestamp t1, string? shardKey = null, int? maxCount = null) where T : struct, IEntry
@@ -597,7 +616,7 @@ public sealed class DebugDb : IDebugDb
         return _sources.Get(id, _strings);
     }
 
-    public void BuildJournal()
+    public void BuildJournal(bool group = true)
     {
         var range = GetFrameRange();
         if (range is null) return;
@@ -608,12 +627,17 @@ public sealed class DebugDb : IDebugDb
 
         lock (_journalLock)
         {
+            _groupJournalEntries = group;
             _journal.Clear();
-            _journal.AddRange(entries);
+            _journalIndex.Clear();
+            foreach (var e in entries)
+                AddToJournal(e);
         }
     }
 
-    public void FillJournal(List<Entry> destination)
+    public void RebuildJournal(bool group) => BuildJournal(group);
+
+    public void FillJournal(List<JournalGroup> destination)
     {
         lock (_journalLock)
         {

--- a/Common/Debug/Db/IDebugDb.cs
+++ b/Common/Debug/Db/IDebugDb.cs
@@ -1,3 +1,5 @@
+using Tyr.Common.Debug.Logging;
+
 namespace Tyr.Common.Debug.Db;
 
 public interface IDebugDb : IDisposable
@@ -13,6 +15,8 @@ public interface IDebugDb : IDisposable
     IEnumerable<Meta> QuerySourceLocations(string module, Type type);
     Meta? TryGetShardMeta<T>(string module, string shardKey) where T : struct, IEntry;
     Meta GetSourceLocation(int id);
+
+    void FillJournal(List<Entry> destination);
 
     void AppendFrame(Frame frame);
     (Timestamp Start, Timestamp End)? GetFrameRange();

--- a/Common/Debug/Db/IDebugDb.cs
+++ b/Common/Debug/Db/IDebugDb.cs
@@ -16,7 +16,8 @@ public interface IDebugDb : IDisposable
     Meta? TryGetShardMeta<T>(string module, string shardKey) where T : struct, IEntry;
     Meta GetSourceLocation(int id);
 
-    void FillJournal(List<Entry> destination);
+    void FillJournal(List<JournalGroup> destination);
+    void RebuildJournal(bool group);
 
     void AppendFrame(Frame frame);
     (Timestamp Start, Timestamp End)? GetFrameRange();

--- a/Common/Debug/Db/JournalGroup.cs
+++ b/Common/Debug/Db/JournalGroup.cs
@@ -1,0 +1,13 @@
+using Tyr.Common.Debug.Logging;
+using Tyr.Common.Time;
+
+namespace Tyr.Common.Debug.Db;
+
+/// <summary>
+/// A journal entry that may represent multiple occurrences of the same log message
+/// (same source location, message text, and level). Count is 1 when grouping is disabled.
+/// </summary>
+public record struct JournalGroup(Entry Entry, int Count, Timestamp LastTime)
+{
+    public Timestamp FirstTime => Entry.Timestamp;
+}

--- a/Common/Debug/Db/ReadOnlyDebugDb.cs
+++ b/Common/Debug/Db/ReadOnlyDebugDb.cs
@@ -37,7 +37,8 @@ public sealed class ReadOnlyDebugDb(IDebugDb inner) : IDebugDb
 
     public Meta GetSourceLocation(int id) => inner.GetSourceLocation(id);
 
-    public void FillJournal(List<Entry> destination) => inner.FillJournal(destination);
+    public void FillJournal(List<JournalGroup> destination) => inner.FillJournal(destination);
+    public void RebuildJournal(bool group) => inner.RebuildJournal(group);
 
     public void AppendFrame(Frame frame)
         => throw new InvalidOperationException("Cannot append frames to a read-only debug database.");

--- a/Common/Debug/Db/ReadOnlyDebugDb.cs
+++ b/Common/Debug/Db/ReadOnlyDebugDb.cs
@@ -1,4 +1,5 @@
 using Tyr.Common.Debug;
+using Tyr.Common.Debug.Logging;
 using Tyr.Common.Time;
 
 namespace Tyr.Common.Debug.Db;
@@ -35,6 +36,8 @@ public sealed class ReadOnlyDebugDb(IDebugDb inner) : IDebugDb
         => inner.TryGetShardMeta<T>(module, shardKey);
 
     public Meta GetSourceLocation(int id) => inner.GetSourceLocation(id);
+
+    public void FillJournal(List<Entry> destination) => inner.FillJournal(destination);
 
     public void AppendFrame(Frame frame)
         => throw new InvalidOperationException("Cannot append frames to a read-only debug database.");

--- a/Gui/Data/PlaybackSessionManager.cs
+++ b/Gui/Data/PlaybackSessionManager.cs
@@ -116,6 +116,7 @@ public sealed class PlaybackSessionManager : IDisposable
 
         var db = new DebugDb(databaseDirectory)
             .RegisterKnownTypes();
+        db.BuildJournal();
 
         var readOnlyDb = new ReadOnlyDebugDb(db);
         _playbackDb.SetSource(readOnlyDb);

--- a/Gui/Data/PlaybackSessionManager.cs
+++ b/Gui/Data/PlaybackSessionManager.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Diagnostics;
 using Tyr.Common.Debug.Db;
 using Tyr.Common.Time;
+using Tyr.Gui.Views;
 
 namespace Tyr.Gui.Data;
 
@@ -116,7 +117,7 @@ public sealed class PlaybackSessionManager : IDisposable
 
         var db = new DebugDb(databaseDirectory)
             .RegisterKnownTypes();
-        db.BuildJournal();
+        db.BuildJournal(LogView.GroupJournalEntries);
 
         var readOnlyDb = new ReadOnlyDebugDb(db);
         _playbackDb.SetSource(readOnlyDb);

--- a/Gui/Data/SwitchableDebugDb.cs
+++ b/Gui/Data/SwitchableDebugDb.cs
@@ -53,6 +53,9 @@ internal sealed class SwitchableDebugDb(IDebugDb source) : IDebugDb
     (Timestamp Start, Timestamp End)? IDebugDb.GetFrameAt(string module, Timestamp t)
         => _source.GetFrameAt(module, t);
 
+    void IDebugDb.FillJournal(List<Tyr.Common.Debug.Logging.Entry> destination)
+        => _source.FillJournal(destination);
+
     void IDisposable.Dispose()
     {
     }

--- a/Gui/Data/SwitchableDebugDb.cs
+++ b/Gui/Data/SwitchableDebugDb.cs
@@ -53,8 +53,9 @@ internal sealed class SwitchableDebugDb(IDebugDb source) : IDebugDb
     (Timestamp Start, Timestamp End)? IDebugDb.GetFrameAt(string module, Timestamp t)
         => _source.GetFrameAt(module, t);
 
-    void IDebugDb.FillJournal(List<Tyr.Common.Debug.Logging.Entry> destination)
+    void IDebugDb.FillJournal(List<Tyr.Common.Debug.Db.JournalGroup> destination)
         => _source.FillJournal(destination);
+    void IDebugDb.RebuildJournal(bool group) => _source.RebuildJournal(group);
 
     void IDisposable.Dispose()
     {

--- a/Gui/Views/LogView.cs
+++ b/Gui/Views/LogView.cs
@@ -17,6 +17,7 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
 {
     public static readonly string WindowTitle = $"{IconFonts.FontAwesome6.Terminal} Logs";
     [ConfigEntry(StorageType.User)] private static LogLevel LogLevel { get; set; } = LogLevel.Debug;
+    [ConfigEntry(StorageType.User)] private static bool JournalMode { get; set; } = false;
 
     private Utf8ValueStringBuilder _stringBuilder = ZString.CreateUtf8StringBuilder();
 
@@ -28,17 +29,26 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
     internal sealed class PreparedData
     {
         public List<Entry> Entries { get; } = [];
+        public List<Entry> JournalEntries { get; } = [];
 
         public void Reset()
         {
             Entries.Clear();
+            JournalEntries.Clear();
         }
     }
 
     internal void Prepare(PlaybackTime time, DebugFilterSnapshot filterSnapshot, PreparedData prepared)
     {
         prepared.Reset();
+        if (JournalMode)
+            PrepareJournal(time, filterSnapshot, prepared);
+        else
+            PreparePerFrame(time, filterSnapshot, prepared);
+    }
 
+    private void PreparePerFrame(PlaybackTime time, DebugFilterSnapshot filterSnapshot, PreparedData prepared)
+    {
         foreach (var module in debugDb.QueryModules())
         {
             if (!filterSnapshot.IsEnabled(module))
@@ -58,6 +68,31 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
 
                 prepared.Entries.Add(log);
             }
+        }
+    }
+
+    private readonly List<Entry> _journalBuffer = [];
+
+    private void PrepareJournal(PlaybackTime time, DebugFilterSnapshot filterSnapshot, PreparedData prepared)
+    {
+        debugDb.FillJournal(_journalBuffer);
+        var cutoffNs = time.Time.Nanoseconds;
+
+        // Binary search: find exclusive upper bound (first entry with Timestamp > cutoff)
+        int lo = 0, hi = _journalBuffer.Count;
+        while (lo < hi)
+        {
+            var mid = lo + (hi - lo) / 2;
+            if (_journalBuffer[mid].Timestamp.Nanoseconds <= cutoffNs) lo = mid + 1;
+            else hi = mid;
+        }
+
+        for (int i = 0; i < lo; i++)
+        {
+            var log = _journalBuffer[i];
+            if (log.Level < LogLevel) continue;
+            if (!filterSnapshot.IsEnabled(log.Meta)) continue;
+            prepared.JournalEntries.Add(log);
         }
     }
 
@@ -94,11 +129,13 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
 
                 ImGui.TableHeadersRow();
 
+                var sourceEntries = JournalMode ? prepared.JournalEntries : prepared.Entries;
+
                 var sortSpecs = ImGui.TableGetSortSpecs();
-                if (!sortSpecs.IsNull && sortSpecs.SpecsCount > 0 && prepared.Entries.Count > 1)
+                if (!sortSpecs.IsNull && sortSpecs.SpecsCount > 0 && sourceEntries.Count > 1)
                 {
                     var spec = sortSpecs.Specs[0];
-                    prepared.Entries.Sort((a, b) =>
+                    sourceEntries.Sort((a, b) =>
                     {
                         int result = spec.ColumnIndex switch
                         {
@@ -121,7 +158,7 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
                 DrawSearchAndFilterControls();
 
                 _filteredEntries.Clear();
-                foreach (var log in prepared.Entries)
+                foreach (var log in sourceEntries)
                 {
                     _filterTested += 1;
                     if (!_filter.PassFilter(log.Message) &&
@@ -251,6 +288,22 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
         {
             ImGui.TextDisabled($"{IconFonts.FontAwesome6.MagnifyingGlass}");
         }
+
+        ImGui.SameLine(0f, 10f);
+        ImGui.TextDisabled("|");
+
+        // journal mode toggle
+        ImGui.SameLine(0f, 10f);
+        var journalActive = JournalMode;
+        if (journalActive) ImGui.PushStyleColor(ImGuiCol.Button, Color.Sky700);
+        if (ImGui.Button($"{IconFonts.FontAwesome6.BookOpen} Journal##journal"))
+        {
+            JournalMode = !JournalMode;
+            Configurable.MarkChanged(StorageType.User);
+        }
+        if (journalActive) ImGui.PopStyleColor();
+        if (ImGui.IsItemHovered(ImGuiHoveredFlags.ForTooltip))
+            ImGui.SetTooltip("Journal mode: show all Information+ logs from session start to current time");
 
         ImGui.SameLine(0f, 10f);
         ImGui.TextDisabled("|");

--- a/Gui/Views/LogView.cs
+++ b/Gui/Views/LogView.cs
@@ -18,6 +18,7 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
     public static readonly string WindowTitle = $"{IconFonts.FontAwesome6.Terminal} Logs";
     [ConfigEntry(StorageType.User)] private static LogLevel LogLevel { get; set; } = LogLevel.Debug;
     [ConfigEntry(StorageType.User)] private static bool JournalMode { get; set; } = false;
+    [ConfigEntry(StorageType.User)] internal static bool GroupJournalEntries { get; set; } = true;
 
     private Utf8ValueStringBuilder _stringBuilder = ZString.CreateUtf8StringBuilder();
 
@@ -29,7 +30,7 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
     internal sealed class PreparedData
     {
         public List<Entry> Entries { get; } = [];
-        public List<Entry> JournalEntries { get; } = [];
+        public List<JournalGroup> JournalEntries { get; } = [];
 
         public void Reset()
         {
@@ -71,32 +72,41 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
         }
     }
 
-    private readonly List<Entry> _journalBuffer = [];
+    private readonly List<JournalGroup> _journalBuffer = [];
+    private bool _prevGroupJournalEntries = true;
 
     private void PrepareJournal(PlaybackTime time, DebugFilterSnapshot filterSnapshot, PreparedData prepared)
     {
+        if (GroupJournalEntries != _prevGroupJournalEntries)
+        {
+            debugDb.RebuildJournal(GroupJournalEntries);
+            _prevGroupJournalEntries = GroupJournalEntries;
+        }
+
         debugDb.FillJournal(_journalBuffer);
         var cutoffNs = time.Time.Nanoseconds;
 
-        // Binary search: find exclusive upper bound (first entry with Timestamp > cutoff)
+        // Binary search: find exclusive upper bound (first group with FirstTime > cutoff)
         int lo = 0, hi = _journalBuffer.Count;
         while (lo < hi)
         {
             var mid = lo + (hi - lo) / 2;
-            if (_journalBuffer[mid].Timestamp.Nanoseconds <= cutoffNs) lo = mid + 1;
+            if (_journalBuffer[mid].FirstTime.Nanoseconds <= cutoffNs) lo = mid + 1;
             else hi = mid;
         }
 
         for (int i = 0; i < lo; i++)
         {
-            var log = _journalBuffer[i];
-            if (log.Level < LogLevel) continue;
-            if (!filterSnapshot.IsEnabled(log.Meta)) continue;
-            prepared.JournalEntries.Add(log);
+            var group = _journalBuffer[i];
+            if (group.Entry.Level < LogLevel) continue;
+            if (!filterSnapshot.IsEnabled(group.Entry.Meta)) continue;
+            prepared.JournalEntries.Add(group);
         }
     }
 
     private readonly List<Entry> _filteredEntries = [];
+    private readonly List<JournalGroup> _filteredJournalEntries = [];
+    private bool _wasJournalMode;
 
     internal void Draw(PreparedData prepared, bool isLive)
     {
@@ -129,56 +139,114 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
 
                 ImGui.TableHeadersRow();
 
-                var sourceEntries = JournalMode ? prepared.JournalEntries : prepared.Entries;
-
                 var sortSpecs = ImGui.TableGetSortSpecs();
-                if (!sortSpecs.IsNull && sortSpecs.SpecsCount > 0 && sourceEntries.Count > 1)
-                {
-                    var spec = sortSpecs.Specs[0];
-                    sourceEntries.Sort((a, b) =>
-                    {
-                        int result = spec.ColumnIndex switch
-                        {
-                            0 or 3 => a.Level.CompareTo(b.Level),
-                            1 => a.Timestamp.CompareTo(b.Timestamp),
-                            2 => string.Compare(a.Meta.Module, b.Meta.Module, StringComparison.Ordinal),
-                            4 => string.Compare(a.Meta.File, b.Meta.File, StringComparison.Ordinal),
-                            5 => string.Compare(a.Meta.Member, b.Meta.Member, StringComparison.Ordinal),
-                            6 => string.Compare(a.Message, b.Message, StringComparison.Ordinal),
-                            _ => 0
-                        };
-
-                        return spec.SortDirection == ImGuiSortDirection.Ascending ? result : -result;
-                    });
-                    sortSpecs.SpecsDirty = false;
-                }
 
                 ImGui.PushFont(FontRegistry.Instance.MonoFont, FontRegistry.Instance.MonoFont.LegacySize);
 
                 DrawSearchAndFilterControls();
 
-                _filteredEntries.Clear();
-                foreach (var log in sourceEntries)
+                if (JournalMode)
                 {
-                    _filterTested += 1;
-                    if (!_filter.PassFilter(log.Message) &&
-                        !_filter.PassFilter(log.Meta.Module))
-                        continue;
-                    _filterPassed += 1;
-                    _filteredEntries.Add(log);
+                    var journalEntries = prepared.JournalEntries;
+
+                    // On mode switch, force time-ascending sort.
+                    if (!_wasJournalMode)
+                    {
+                        journalEntries.Sort((a, b) => a.FirstTime.CompareTo(b.FirstTime));
+                        sortSpecs.SpecsDirty = false;
+                    }
+                    else if (!sortSpecs.IsNull && sortSpecs.SpecsCount > 0 && journalEntries.Count > 1)
+                    {
+                        var spec = sortSpecs.Specs[0];
+                        journalEntries.Sort((a, b) =>
+                        {
+                            int result = spec.ColumnIndex switch
+                            {
+                                0 or 3 => a.Entry.Level.CompareTo(b.Entry.Level),
+                                1 => a.FirstTime.CompareTo(b.FirstTime),
+                                2 => string.Compare(a.Entry.Meta.Module, b.Entry.Meta.Module, StringComparison.Ordinal),
+                                4 => string.Compare(a.Entry.Meta.File, b.Entry.Meta.File, StringComparison.Ordinal),
+                                5 => string.Compare(a.Entry.Meta.Member, b.Entry.Meta.Member, StringComparison.Ordinal),
+                                6 => string.Compare(a.Entry.Message, b.Entry.Message, StringComparison.Ordinal),
+                                _ => 0
+                            };
+                            return spec.SortDirection == ImGuiSortDirection.Ascending ? result : -result;
+                        });
+                        sortSpecs.SpecsDirty = false;
+                    }
+
+                    _filteredJournalEntries.Clear();
+                    foreach (var group in journalEntries)
+                    {
+                        _filterTested += 1;
+                        if (!_filter.PassFilter(group.Entry.Message) &&
+                            !_filter.PassFilter(group.Entry.Meta.Module))
+                            continue;
+                        _filterPassed += 1;
+                        _filteredJournalEntries.Add(group);
+                    }
+
+                    ImGuiListClipperPtr clipper = ImGui.ImGuiListClipper();
+                    clipper.Begin(_filteredJournalEntries.Count);
+                    while (clipper.Step())
+                    {
+                        for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                        {
+                            ImGui.TableNextRow();
+                            DrawJournalEntry(_filteredJournalEntries[i]);
+                        }
+                    }
+                    clipper.End();
+                }
+                else
+                {
+                    var frameEntries = prepared.Entries;
+
+                    if (!sortSpecs.IsNull && sortSpecs.SpecsCount > 0 && frameEntries.Count > 1)
+                    {
+                        var spec = sortSpecs.Specs[0];
+                        frameEntries.Sort((a, b) =>
+                        {
+                            int result = spec.ColumnIndex switch
+                            {
+                                0 or 3 => a.Level.CompareTo(b.Level),
+                                1 => a.Timestamp.CompareTo(b.Timestamp),
+                                2 => string.Compare(a.Meta.Module, b.Meta.Module, StringComparison.Ordinal),
+                                4 => string.Compare(a.Meta.File, b.Meta.File, StringComparison.Ordinal),
+                                5 => string.Compare(a.Meta.Member, b.Meta.Member, StringComparison.Ordinal),
+                                6 => string.Compare(a.Message, b.Message, StringComparison.Ordinal),
+                                _ => 0
+                            };
+                            return spec.SortDirection == ImGuiSortDirection.Ascending ? result : -result;
+                        });
+                        sortSpecs.SpecsDirty = false;
+                    }
+
+                    _filteredEntries.Clear();
+                    foreach (var log in frameEntries)
+                    {
+                        _filterTested += 1;
+                        if (!_filter.PassFilter(log.Message) &&
+                            !_filter.PassFilter(log.Meta.Module))
+                            continue;
+                        _filterPassed += 1;
+                        _filteredEntries.Add(log);
+                    }
+
+                    ImGuiListClipperPtr clipper = ImGui.ImGuiListClipper();
+                    clipper.Begin(_filteredEntries.Count);
+                    while (clipper.Step())
+                    {
+                        for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
+                        {
+                            ImGui.TableNextRow();
+                            DrawLogEntry(_filteredEntries[i]);
+                        }
+                    }
+                    clipper.End();
                 }
 
-                ImGuiListClipperPtr clipper = ImGui.ImGuiListClipper();
-                clipper.Begin(_filteredEntries.Count);
-                while (clipper.Step())
-                {
-                    for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
-                    {
-                        ImGui.TableNextRow();
-                        DrawLogEntry(_filteredEntries[i]);
-                    }
-                }
-                clipper.End();
+                _wasJournalMode = JournalMode;
 
                 ImGui.PopFont();
 
@@ -263,6 +331,74 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
         ImGui.PopStyleColor();
     }
 
+    private void DrawJournalEntry(JournalGroup group)
+    {
+        var log = group.Entry;
+        var color = log.Level switch
+        {
+            LogLevel.Trace => Color.Slate300,
+            LogLevel.Debug => Color.Teal200,
+            LogLevel.Information => Color.Sky200,
+            LogLevel.Warning => Color.Yellow300,
+            LogLevel.Error => Color.Red400,
+            LogLevel.Critical => Color.Fuchsia400,
+            _ => Color.White,
+        };
+        ImGui.PushStyleColor(ImGuiCol.Text, color.RGBA);
+
+        ImGui.TableNextColumn();
+        var icon = log.Level switch
+        {
+            LogLevel.Trace => IconFonts.FontAwesome6.UserSecret,
+            LogLevel.Debug => IconFonts.FontAwesome6.Bug,
+            LogLevel.Information => IconFonts.FontAwesome6.CircleExclamation,
+            LogLevel.Warning => IconFonts.FontAwesome6.TriangleExclamation,
+            LogLevel.Error => IconFonts.FontAwesome6.Radiation,
+            LogLevel.Critical => IconFonts.FontAwesome6.SkullCrossbones,
+            _ => IconFonts.FontAwesome6.Question,
+        };
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ImGui.GetFontSize() / 4f);
+        ImGui.TextUnformatted(icon);
+
+        ImGui.TableNextColumn();
+        _stringBuilder.Clear();
+        _stringBuilder.AppendFormat("{0:D2}:{1:D2}:{2:D2}.{3:D3}\0",
+            (int)log.Timestamp.NormalizedHours,
+            (int)log.Timestamp.NormalizedMinutes,
+            (int)log.Timestamp.NormalizedSeconds,
+            (int)log.Timestamp.NormalizedMilliseconds);
+        ImGui.TextUnformatted(_stringBuilder.AsSpan());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(log.Meta.Module);
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(Debug.EnumCache<LogLevel>.GetName(log.Level));
+
+        ImGui.TableNextColumn();
+        _stringBuilder.Clear();
+        _stringBuilder.AppendFormat("{0}: {1}\0",
+            Debug.PathCache.GetFileName(log.Meta.File), log.Meta.Line);
+        ImGui.TextUnformatted(_stringBuilder.AsSpan());
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted(log.Meta.Member);
+
+        ImGui.TableNextColumn();
+        if (group.Count > 1)
+        {
+            _stringBuilder.Clear();
+            _stringBuilder.AppendFormat("[×{0}] {1}\0", group.Count, log.Message);
+            ImGui.TextUnformatted(_stringBuilder.AsSpan());
+        }
+        else
+        {
+            ImGui.TextUnformatted(log.Message);
+        }
+
+        ImGui.PopStyleColor();
+    }
+
     private void DrawSearchAndFilterControls()
     {
         // search bar
@@ -304,6 +440,21 @@ public sealed partial class LogView(IDebugDb debugDb) : IDisposable
         if (journalActive) ImGui.PopStyleColor();
         if (ImGui.IsItemHovered(ImGuiHoveredFlags.ForTooltip))
             ImGui.SetTooltip("Journal mode: show all Information+ logs from session start to current time");
+
+        // Group toggle — only meaningful in journal mode
+        ImGui.SameLine(0f, 4f);
+        if (!journalActive) ImGui.BeginDisabled();
+        var groupActive = GroupJournalEntries;
+        if (groupActive) ImGui.PushStyleColor(ImGuiCol.Button, Color.Sky700);
+        if (ImGui.Button($"{IconFonts.FontAwesome6.LayerGroup}##group"))
+        {
+            GroupJournalEntries = !GroupJournalEntries;
+            Configurable.MarkChanged(StorageType.User);
+        }
+        if (groupActive) ImGui.PopStyleColor();
+        if (!journalActive) ImGui.EndDisabled();
+        if (ImGui.IsItemHovered(ImGuiHoveredFlags.ForTooltip))
+            ImGui.SetTooltip("Group repeated journal entries (rebuilds from disk when toggled)");
 
         ImGui.SameLine(0f, 10f);
         ImGui.TextDisabled("|");

--- a/Vision/Camera.cs
+++ b/Vision/Camera.cs
@@ -68,10 +68,10 @@ public partial class Camera(uint id)
         // frame id
         if (FrameId != 0 && frame.FrameNumber == FrameId)
         {
-            Log.ZLogWarning($"Camera {Id} received duplicate frame id {frame.FrameNumber}");
+            Log.ZLogWarning($"Camera {Id} received duplicate frame id");
             return;
         }
-        
+
         var expectedFrameId = FrameId == 0 ? frame.FrameNumber : FrameId + 1;
         if (frame.FrameNumber != expectedFrameId)
         {
@@ -187,7 +187,7 @@ public partial class Camera(uint id)
                 }
 
                 tracker = filteredRobot != null
-                    ? new RobotTracker(this, robot, filteredRobot.Value, color) // on a different camera already 
+                    ? new RobotTracker(this, robot, filteredRobot.Value, color) // on a different camera already
                     : new RobotTracker(this, robot, color); // completely new robot on the field
 
 


### PR DESCRIPTION
## Summary
This PR adds a "Journal Mode" feature to the LogView that displays all Information+ level logs from the start of a session to the current playback time, complementing the existing per-frame log view.

## Key Changes
- **LogView UI**: Added a toggle button to switch between per-frame and journal mode views
  - Journal mode displays logs chronologically from session start to current time
  - Per-frame mode maintains the existing behavior
  - Toggle state is persisted as a user configuration entry

- **DebugDb Journal Storage**: Implemented journal functionality to maintain a filtered log history
  - Logs at Information level and above are automatically added to the journal when appended
  - `BuildJournal()` method reconstructs the journal from the full frame range on session load
  - `FillJournal()` method provides thread-safe access to the journal via a lock

- **Interface Updates**: Extended `IDebugDb` interface with `FillJournal()` method
  - Implemented in `DebugDb`, `ReadOnlyDebugDb`, and `SwitchableDebugDb`

- **Session Initialization**: Journal is built when opening a playback session via `PlaybackSessionManager`

## Implementation Details
- Journal entries are filtered by `LogLevel.Information` minimum threshold
- Binary search is used in `PrepareJournal()` to efficiently find the cutoff point for the current playback time
- Thread-safe journal access using locks to prevent race conditions during concurrent log appending
- The journal view reuses the existing filtering and sorting infrastructure by switching the source entries list

https://claude.ai/code/session_013uZ5TJ8nePqHnRXJY7D1qM