### PR TITLE
⚡ Bolt: Eliminate LINQ and debug log allocations in hot path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-04-12 - Avoid LINQ in per-frame hot path
 **Learning:** LINQ methods like `Where` and `FirstOrDefault` implicitly allocate enumerators and closures when capturing state (e.g., `Context.Color` or lambda expressions). In a 100Hz real-time loop like `Ai.UpdateContext()` and `Ai.Process()`, these allocations stack up quickly, causing significant GC pressure and potential micro-stutters.
 **Action:** Replace `LINQ` operations with manual `foreach` or `for` loops in the per-frame hot path to achieve zero-allocation data iteration.
+
+## 2026-05-28 - String Interpolation and LINQ inside Log calls
+**Learning:** `Log.ZLogDebug` calls that include string interpolation (using `$""`) combined with complex expressions like `string.Join` and `.Select()` will evaluate these expressions and allocate memory (strings, closures, arrays) *before* the logger's internal log level filter is checked. If debug logging is disabled, these allocations are completely wasted.
+**Action:** Always wrap expensive log messages (those doing LINQ, allocations, or complex string concatenations) inside an explicit `if (Log.IsEnabled(LogLevel.Debug))` block to prevent evaluating the arguments when the log level is not active.

--- a/Soccer/Ai.cs
+++ b/Soccer/Ai.cs
@@ -174,9 +174,13 @@ public partial class Ai
         var newRoleMapping = assignmentResult.RoleMapping;
 
         Log.ZLogDebug($"Role assignment total cost: {assignmentResult.TotalCost:F3}");
-        foreach (var unfilledRole in assignmentResult.UnfilledRoles.Where(r => r.IsRequired))
+        // Bolt: eliminates LINQ .Where() closure and enumerator allocs per frame
+        foreach (var unfilledRole in assignmentResult.UnfilledRoles)
         {
-            Log.ZLogWarning($"Required role left unfilled: {unfilledRole.Role}");
+            if (unfilledRole.IsRequired)
+            {
+                Log.ZLogWarning($"Required role left unfilled: {unfilledRole.Role}");
+            }
         }
 
         Context.Data.Value = Context.Data.Value! with

--- a/Soccer/Knowledge/Knowledge.AttackerDecision.cs
+++ b/Soccer/Knowledge/Knowledge.AttackerDecision.cs
@@ -25,6 +25,7 @@ public partial class Knowledge
 
     private readonly Dictionary<int, AttackerDecision> _attackerDecisions = [];
     private readonly Dictionary<int, int> _passShootHysteresisByRobot = [];
+    private readonly List<int> _staleHysteresisKeys = []; // Bolt: pre-allocated list to avoid per-frame allocations
 
     public AttackerDecision GetAttackerDecision(int robotId)
     {
@@ -49,7 +50,17 @@ public partial class Knowledge
             _attackerDecisions[robotId] = BuildAttackerDecision(assignment.Robot, attackerRole);
         }
 
-        foreach (var robotId in _passShootHysteresisByRobot.Keys.Where(id => !assignedAttackers.Contains(id)).ToList())
+        // Bolt: eliminates LINQ .Where(...).ToList() allocation per frame
+        _staleHysteresisKeys.Clear();
+        foreach (var robotId in _passShootHysteresisByRobot.Keys)
+        {
+            if (!assignedAttackers.Contains(robotId))
+            {
+                _staleHysteresisKeys.Add(robotId);
+            }
+        }
+
+        foreach (var robotId in _staleHysteresisKeys)
         {
             _passShootHysteresisByRobot.Remove(robotId);
         }

--- a/Soccer/TeamRunner.cs
+++ b/Soccer/TeamRunner.cs
@@ -100,8 +100,11 @@ public sealed partial class TeamRunner : IDisposable
             ApplySimFeedback(simFeedback);
 
 
-        foreach (var robot in Context.OwnRobots.Where(r => r.HardwareStatus.IsValid()))
+        // Bolt: eliminates LINQ .Where() closure and enumerator allocs per frame
+        foreach (var robot in Context.OwnRobots)
         {
+            if (!robot.HardwareStatus.IsValid()) continue;
+
             var now = Timestamp.Now;
             if (now - robot.HardwareStatus.LastUpdate > HardwareStatusValidTime)
             {
@@ -126,12 +129,16 @@ public sealed partial class TeamRunner : IDisposable
                 }
             }
 
-            Log.ZLogDebug(
-                $"Robot {status.Info!.RobotId}: " +
-                $"battery={status.Power?.V24Voltage:F2}V " +
-                $"temp={status.Diag?.ImuTemp:F1}°C " +
-                $"ball={robot.HasBallContact} " +
-                $"motors=[{string.Join(", ", status.Motors?.Motors.Select(m => $"{m.Target:F0}/{m.Actual:F0}") ?? [])}]");
+            // Bolt: gates expensive LINQ and string interpolation inside the hot path when debug logs are off
+            if (Log.IsEnabled(LogLevel.Debug))
+            {
+                Log.ZLogDebug(
+                    $"Robot {status.Info!.RobotId}: " +
+                    $"battery={status.Power?.V24Voltage:F2}V " +
+                    $"temp={status.Diag?.ImuTemp:F1}°C " +
+                    $"ball={robot.HasBallContact} " +
+                    $"motors=[{string.Join(", ", status.Motors?.Motors.Select(m => $"{m.Target:F0}/{m.Actual:F0}") ?? [])}]");
+            }
         }
 
         if (_refereeSubscriber.Reader.TryRead(out var referee))

--- a/Soccer/TeamRunner.cs
+++ b/Soccer/TeamRunner.cs
@@ -130,7 +130,7 @@ public sealed partial class TeamRunner : IDisposable
             }
 
             // Bolt: gates expensive LINQ and string interpolation inside the hot path when debug logs are off
-            if (Log.IsEnabled(LogLevel.Debug))
+            if (Log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
             {
                 Log.ZLogDebug(
                     $"Robot {status.Info!.RobotId}: " +


### PR DESCRIPTION
💡 **What:** 
- Removed LINQ `.Where()` and `.ToList()` usage in the per-frame loops of `TeamRunner`, `Ai`, and `Knowledge.AttackerDecision`.
- Gated expensive debug logging inside `TeamRunner` behind `if (Log.IsEnabled(LogLevel.Debug))`.
- Documented findings regarding `ZLogDebug` parameter evaluation in `.jules/bolt.md`.

🎯 **Why:** 
- LINQ operations create enumerators and closure allocations (when capturing class state or local variables). Doing this in a 100Hz loop creates immense, steady garbage generation, resulting in GC pauses which must be avoided for real-time robotic operations. 
- Using string interpolations with `.Select()` or `string.Join` inside a log call results in heap allocations that happen *before* the logger's internal log level is evaluated. When `Debug` logs are disabled, these thousands of allocations are purely wasted compute and garbage.

📊 **Impact:** 
- Eliminates 3 primary per-frame LINQ closure/enumerator allocations.
- Eliminates thousands of per-second string array and closure allocations when debug logging is disabled in `TeamRunner`.

🔬 **Measurement:**
`dotnet-counters monitor -p <PID> --counters System.Runtime[gen-0-gc-count,alloc-rate]`

---
*PR created automatically by Jules for task [10326074954020290042](https://jules.google.com/task/10326074954020290042) started by @lordhippo*